### PR TITLE
Add basic interest rate swap pricing utilities and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v1
+      - run: uv sync
+      - run: uv run ruff check .
+      - run: uv run black --check .
+      - run: uv run mypy src
+      - run: uv run pytest -q
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.venv/
+*.egg-info/
+build/
+dist/
+uv.lock
+

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,6 @@
+line-length = 88
+target-version = "py310"
+
+[lint]
+select = ["E", "F", "I"]
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+PY = uv run python
+
+.PHONY: setup format lint test run-example
+
+setup:
+uv venv
+uv sync
+
+format:
+uv run black src tests
+
+lint:
+uv run ruff check .
+uv run black --check src tests
+uv run mypy src
+
+test:
+uv run pytest -q
+
+run-example:
+uv run python -m pricingengine.examples.price_irs
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# PricingEngine
+
+Tiny educational project showing how to build and price a vanilla
+interest‑rate swap using [QuantLib](https://www.quantlib.org/).
+
+## Quickstart
+
+The project uses [uv](https://github.com/astral-sh/uv) for dependency
+management.
+
+```bash
+uv venv              # create virtualenv
+uv sync              # install deps and the package itself
+uv run pytest -q     # run tests
+```
+
+To format, lint and type‑check the code:
+
+```bash
+make format
+make lint
+```
+
+## Example
+
+An executable example is provided which prices a 5Y fixed‑vs‑float IRS
+on flat curves and prints the MTM and PV01 along with the first cashflow
+rows.
+
+```bash
+uv run python -m pricingengine.examples.price_irs
+```
+
+## Repository layout
+
+```
+src/pricingengine/          # package code
+├── cashflows/              # fixed and floating leg helpers
+├── indices/                # utilities for rate indices
+├── instruments/            # common instrument interfaces
+├── termstructures/         # curve node container
+└── irs.py                  # InterestRateSwap implementation
+```
+
+Tests live under `tests/` and can be executed via `make test` or the
+`uv run pytest -q` command shown above.
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.10
+warn_unused_ignores = True
+ignore_missing_imports = True
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pricingengine"
+version = "0.1.0"
+description = "Tiny pricing engine for interest-rate swaps"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "QuantLib",
+    "pandas",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "ruff",
+    "black",
+    "mypy",
+    "typing-extensions",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+
+[tool.uv]
+dev-dependencies = [
+    "pytest",
+    "ruff",
+    "black",
+    "mypy",
+    "typing-extensions",
+]
+

--- a/src/pricingengine/__init__.py
+++ b/src/pricingengine/__init__.py
@@ -1,0 +1,6 @@
+"""Top-level package for the pricing engine."""
+
+from .irs import InterestRateSwap
+from .termstructures.curve_nodes import CurveNodes
+
+__all__ = ["InterestRateSwap", "CurveNodes"]

--- a/src/pricingengine/cashflows/__init__.py
+++ b/src/pricingengine/cashflows/__init__.py
@@ -1,0 +1,5 @@
+"""Cashflow builders."""
+
+from .swap_leg import FixedLeg, FloatingLeg, SwapLeg
+
+__all__ = ["SwapLeg", "FixedLeg", "FloatingLeg"]

--- a/src/pricingengine/cashflows/swap_leg.py
+++ b/src/pricingengine/cashflows/swap_leg.py
@@ -1,0 +1,71 @@
+"""Swap leg building utilities."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from QuantLib import (
+    CashFlow,
+    Date,
+    DayCounter,
+    FixedRateLeg,
+    IborLeg,
+    Index,
+    Schedule,
+)
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SwapLeg(ABC):
+    """Common fields for swap legs."""
+
+    valuation_date: Date
+    issue_date: Date
+    maturity: Date
+    currency: str
+    day_counter: DayCounter
+    future_schedule: Schedule
+    nominal: float
+
+    @abstractmethod
+    def cashflows(self, *, forecast_index: Index | None = None) -> list[CashFlow]:
+        """Return QuantLib cashflows for this leg."""
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class FixedLeg(SwapLeg):
+    """Fixed-rate leg."""
+
+    rate: float
+
+    def cashflows(self, *, forecast_index: Index | None = None) -> list[CashFlow]:
+        leg = FixedRateLeg(
+            self.future_schedule,
+            self.day_counter,
+            [self.nominal],
+            [self.rate],
+        )
+        return list(leg)
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class FloatingLeg(SwapLeg):
+    """Floating-rate leg referencing an Ibor-like index."""
+
+    spread: float = 0.0
+
+    def cashflows(self, *, forecast_index: Index | None = None) -> list[CashFlow]:
+        if forecast_index is None:
+            raise ValueError("forecast_index required for floating leg cashflows")
+        leg = IborLeg(
+            [self.nominal],
+            self.future_schedule,
+            forecast_index,
+            paymentDayCounter=self.day_counter,
+            spreads=[self.spread],
+        )
+        return list(leg)
+
+
+__all__ = ["SwapLeg", "FixedLeg", "FloatingLeg"]

--- a/src/pricingengine/examples/price_irs.py
+++ b/src/pricingengine/examples/price_irs.py
@@ -1,0 +1,114 @@
+"""Small demo wiring up flat curves and pricing an IRS."""
+
+from __future__ import annotations
+
+import pandas as pd
+from QuantLib import (
+    TARGET,
+    Actual365Fixed,
+    Date,
+    DateGeneration,
+    ModifiedFollowing,
+    Months,
+    Period,
+    Schedule,
+    Settings,
+    Years,
+)
+
+from pricingengine.cashflows.swap_leg import FixedLeg, FloatingLeg
+from pricingengine.indices.index_utils import make_forecast_index
+from pricingengine.irs import InterestRateSwap
+from pricingengine.termstructures.curve_nodes import CurveNodes
+
+
+def main() -> None:
+    asof = Date.todaysDate()
+    Settings.instance().evaluationDate = asof
+
+    calendar = TARGET()
+    issue = asof
+    maturity = calendar.advance(issue, Period(5, Years))
+
+    fixed_schedule = Schedule(
+        issue,
+        maturity,
+        Period(12, Months),
+        calendar,
+        ModifiedFollowing,
+        ModifiedFollowing,
+        DateGeneration.Forward,
+        False,
+    )
+    float_schedule = Schedule(
+        issue,
+        maturity,
+        Period(6, Months),
+        calendar,
+        ModifiedFollowing,
+        ModifiedFollowing,
+        DateGeneration.Forward,
+        False,
+    )
+
+    dc = Actual365Fixed()
+
+    discount_nodes = CurveNodes(
+        asof=asof,
+        dates=[maturity],
+        quotes=[0.02],
+        day_count=dc,
+        quote_kind="flat",
+        role="discounting",
+    )
+    forecast_nodes = CurveNodes(
+        asof=asof,
+        dates=[maturity],
+        quotes=[0.025],
+        day_count=dc,
+        quote_kind="flat",
+        role="forecasting",
+    )
+
+    index = make_forecast_index("euribor6m", forecast_nodes)
+
+    notional = 1_000_000
+    fixed_leg = FixedLeg(
+        valuation_date=asof,
+        issue_date=issue,
+        maturity=maturity,
+        currency="EUR",
+        day_counter=dc,
+        future_schedule=fixed_schedule,
+        nominal=notional,
+        rate=0.023,
+    )
+    float_leg = FloatingLeg(
+        valuation_date=asof,
+        issue_date=issue,
+        maturity=maturity,
+        currency="EUR",
+        day_counter=dc,
+        future_schedule=float_schedule,
+        nominal=notional,
+        spread=0.0,
+    )
+
+    swap = InterestRateSwap(paying_leg=fixed_leg, receiving_leg=float_leg)
+
+    mtm = swap.mtm(index, discount_nodes)
+    pv01 = swap.pv01(index, discount_nodes)
+    print(f"MTM: {mtm:.2f}")
+    print(f"PV01: {pv01:.2f}")
+
+    rows = []
+    for cf in fixed_leg.cashflows():
+        rows.append({"leg": "fixed", "date": cf.date(), "amount": cf.amount()})
+    for cf in float_leg.cashflows(forecast_index=index):
+        rows.append({"leg": "float", "date": cf.date(), "amount": cf.amount()})
+    df = pd.DataFrame(rows).sort_values("date").reset_index(drop=True)
+    print(df.head())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pricingengine/indices/__init__.py
+++ b/src/pricingengine/indices/__init__.py
@@ -1,0 +1,5 @@
+"""Index helpers."""
+
+from .index_utils import make_forecast_index
+
+__all__ = ["make_forecast_index"]

--- a/src/pricingengine/indices/index_utils.py
+++ b/src/pricingengine/indices/index_utils.py
@@ -1,0 +1,34 @@
+"""Helpers for working with rate indices."""
+
+from __future__ import annotations
+
+from QuantLib import Euribor6M, Index, Months, Period, Simple, USDLibor
+
+from pricingengine.termstructures.curve_nodes import CurveNodes
+
+
+def make_forecast_index(name: str, forecast_nodes: CurveNodes) -> Index:
+    """Create an Ibor-like index linked to the supplied forecast curve."""
+
+    handle = forecast_nodes.to_handle()
+    key = name.lower()
+    if "eur" in key:
+        index: Index = Euribor6M(handle)
+    elif "usd" in key or "libor" in key:
+        index = USDLibor(Period(6, Months), handle)
+    else:
+        # default to Euribor6M when unsure
+        index = Euribor6M(handle)
+
+    fixing_date = index.fixingDate(forecast_nodes.asof)
+    rate = handle.forwardRate(
+        forecast_nodes.asof,
+        forecast_nodes.asof + index.tenor(),
+        index.dayCounter(),
+        Simple,
+    ).rate()
+    index.addFixing(fixing_date, rate)
+    return index
+
+
+__all__ = ["make_forecast_index"]

--- a/src/pricingengine/instruments/__init__.py
+++ b/src/pricingengine/instruments/__init__.py
@@ -1,0 +1,5 @@
+"""Instrument interfaces."""
+
+from ._instrument import Instrument, RiskResult
+
+__all__ = ["Instrument", "RiskResult"]

--- a/src/pricingengine/instruments/_instrument.py
+++ b/src/pricingengine/instruments/_instrument.py
@@ -1,0 +1,31 @@
+"""Shared instrument interfaces."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(slots=True)
+class RiskResult:
+    """Container for simple risk measures.
+
+    Only a couple of common Greeks are provided for now; extend as needed.
+    """
+
+    dv01: Optional[float] = None
+    delta: Optional[float] = None
+    gamma: Optional[float] = None
+
+
+class Instrument(ABC):
+    """Abstract base class for priced instruments."""
+
+    @abstractmethod
+    def price(self, *args, **kwargs) -> float:
+        """Return a price for the instrument."""
+
+    @abstractmethod
+    def mtm(self, *args, **kwargs) -> float:
+        """Alias for the mark-to-market (NPV) price."""

--- a/src/pricingengine/termstructures/__init__.py
+++ b/src/pricingengine/termstructures/__init__.py
@@ -1,0 +1,5 @@
+"""Term-structure helpers."""
+
+from .curve_nodes import CurveNodes
+
+__all__ = ["CurveNodes"]

--- a/tests/test_api_surface.py
+++ b/tests/test_api_surface.py
@@ -1,0 +1,9 @@
+from pricingengine.irs import InterestRateSwap
+from pricingengine.termstructures.curve_nodes import CurveNodes
+
+
+def test_api_surface() -> None:
+    assert hasattr(CurveNodes, "bump")
+    assert hasattr(CurveNodes, "yts_handle")
+    assert hasattr(InterestRateSwap, "pv01")
+    assert hasattr(InterestRateSwap, "fixed_leg_bpv")

--- a/tests/test_curve_nodes.py
+++ b/tests/test_curve_nodes.py
@@ -1,0 +1,51 @@
+import math
+
+import QuantLib as ql
+
+from pricingengine.termstructures.curve_nodes import CurveNodes
+
+
+def test_flat_curve_discount_and_bump() -> None:
+    asof = ql.Date(1, 1, 2020)
+    ql.Settings.instance().evaluationDate = asof
+    dc = ql.Actual365Fixed()
+    nodes = CurveNodes(
+        asof=asof,
+        dates=[asof + ql.Period(1, ql.Years)],
+        quotes=[0.02],
+        day_count=dc,
+        quote_kind="flat",
+    )
+    d = nodes.yts_handle().discount(asof + ql.Period(5, ql.Years))
+    t = dc.yearFraction(asof, asof + ql.Period(5, ql.Years))
+    assert abs(d - math.exp(-0.02 * t)) < 1e-9
+
+    bumped = nodes.bump(1.0)
+    d_b = bumped.yts_handle().discount(asof + ql.Period(5, ql.Years))
+    assert abs(d_b - math.exp(-(0.02 + 0.0001) * t)) < 1e-9
+
+
+def test_discount_curve_bump_recomputes() -> None:
+    asof = ql.Date(1, 1, 2020)
+    ql.Settings.instance().evaluationDate = asof
+    dc = ql.Actual365Fixed()
+
+    date1 = asof + ql.Period(1, ql.Years)
+    date5 = asof + ql.Period(5, ql.Years)
+    t1 = dc.yearFraction(asof, date1)
+    t5 = dc.yearFraction(asof, date5)
+    df1 = math.exp(-0.02 * t1)
+    df5 = math.exp(-0.02 * t5)
+    nodes = CurveNodes(
+        asof=asof,
+        dates=[date1, date5],
+        quotes=[df1, df5],
+        day_count=dc,
+        quote_kind="discount",
+    )
+    assert abs(nodes.discount_factor(date5) - df5) < 1e-12
+
+    bumped = nodes.bump(1.0)
+    d_b = bumped.discount_factor(date5)
+    expected = df5 * math.exp(-0.0001 * t5)
+    assert abs(d_b - expected) < 1e-12

--- a/tests/test_irs_smoke.py
+++ b/tests/test_irs_smoke.py
@@ -1,0 +1,102 @@
+import QuantLib as ql
+
+from pricingengine.cashflows.swap_leg import FixedLeg, FloatingLeg
+from pricingengine.indices.index_utils import make_forecast_index
+from pricingengine.irs import InterestRateSwap
+from pricingengine.termstructures.curve_nodes import CurveNodes
+
+
+def _build_curves():
+    asof = ql.Date(1, 1, 2020)
+    ql.Settings.instance().evaluationDate = asof
+    dc = ql.Actual365Fixed()
+    disc = CurveNodes(
+        asof=asof,
+        dates=[asof + ql.Period(50, ql.Years)],
+        quotes=[0.02],
+        day_count=dc,
+        quote_kind="flat",
+        role="discounting",
+    )
+    fwd = CurveNodes(
+        asof=asof,
+        dates=[asof + ql.Period(50, ql.Years)],
+        quotes=[0.025],
+        day_count=dc,
+        quote_kind="flat",
+        role="forecasting",
+    )
+    return asof, dc, disc, fwd
+
+
+def _build_swap(asof: ql.Date, dc: ql.DayCounter) -> InterestRateSwap:
+    calendar = ql.TARGET()
+    issue = asof
+    maturity = calendar.advance(issue, ql.Period(5, ql.Years))
+    fixed_schedule = ql.Schedule(
+        issue,
+        maturity,
+        ql.Period(ql.Annual),
+        calendar,
+        ql.ModifiedFollowing,
+        ql.ModifiedFollowing,
+        ql.DateGeneration.Forward,
+        False,
+    )
+    float_schedule = ql.Schedule(
+        issue,
+        maturity,
+        ql.Period(ql.Semiannual),
+        calendar,
+        ql.ModifiedFollowing,
+        ql.ModifiedFollowing,
+        ql.DateGeneration.Forward,
+        False,
+    )
+    notional = 1_000_000
+    fixed_leg = FixedLeg(
+        valuation_date=asof,
+        issue_date=issue,
+        maturity=maturity,
+        currency="EUR",
+        day_counter=dc,
+        future_schedule=fixed_schedule,
+        nominal=notional,
+        rate=0.023,
+    )
+    float_leg = FloatingLeg(
+        valuation_date=asof,
+        issue_date=issue,
+        maturity=maturity,
+        currency="EUR",
+        day_counter=dc,
+        future_schedule=float_schedule,
+        nominal=notional,
+        spread=0.0,
+    )
+    return InterestRateSwap(paying_leg=fixed_leg, receiving_leg=float_leg)
+
+
+def test_irs_smoke() -> None:
+    asof, dc, disc_nodes, fwd_nodes = _build_curves()
+    index = make_forecast_index("euribor6m", fwd_nodes)
+    swap = _build_swap(asof, dc)
+
+    mtm = swap.mtm(index, disc_nodes)
+    assert isinstance(mtm, float)
+
+    pv01 = swap.pv01(index, disc_nodes)
+    assert abs(pv01) > 0
+
+    assert (
+        abs(
+            swap.fixed_leg_bpv(index, disc_nodes)
+            - swap.float_leg_bpv(index, disc_nodes)
+        )
+        < 1_000_000
+    )
+
+    bumped = disc_nodes.bump(1.0)
+    mtm_bumped = swap.mtm(index, bumped)
+    fd = mtm_bumped - mtm
+    assert abs(fd - pv01) < 1e-2 * 1_000_000


### PR DESCRIPTION
## Summary
- Move existing curve and swap code into a package structure
- Add swap leg builders, instrument base, index utilities and example
- Configure project tooling (uv, ruff, black, mypy) and CI workflow
- Provide unit tests for curve bumping and IRS pricing

## Testing
- `ruff check .`
- `black --check src tests`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b758a697f4832f88eb5c04bec00186