### PR TITLE
Add option and FX instruments with revamped swap legs

### DIFF
--- a/pricingengine/__init__.py
+++ b/pricingengine/__init__.py
@@ -1,0 +1,25 @@
+"""PricingEngine public API."""
+
+from .structures import CurveNodes
+from .indices import make_forecast_index
+from .cashflows import SwapLeg, FixedLeg, FloatingLeg
+from .instruments import (
+    Instrument,
+    InterestRateSwap,
+    FXForward,
+    EquityOption,
+    Swaption,
+)
+
+__all__ = [
+    "CurveNodes",
+    "make_forecast_index",
+    "SwapLeg",
+    "FixedLeg",
+    "FloatingLeg",
+    "Instrument",
+    "InterestRateSwap",
+    "FXForward",
+    "EquityOption",
+    "Swaption",
+]

--- a/pricingengine/cashflows/__init__.py
+++ b/pricingengine/cashflows/__init__.py
@@ -1,1 +1,5 @@
+"""Cashflow leg helpers."""
+
+from .swap_leg import SwapLeg, FixedLeg, FloatingLeg
+
 __all__ = ["SwapLeg", "FixedLeg", "FloatingLeg"]

--- a/pricingengine/cashflows/swap_leg.py
+++ b/pricingengine/cashflows/swap_leg.py
@@ -1,30 +1,50 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from abc import ABC, abstractmethod
 
 from QuantLib import (
     Date,
     DayCounter,
+    Schedule,
     FixedRateLeg,
     IborLeg,
+    Index,
 )
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
+class SwapLeg(ABC):
+    """Base class for a swap leg.
+
+    Holds the minimal information shared by fixed and floating legs and
+    exposes an abstract :meth:`cashflows` method that returns a QuantLib
+    ``Leg`` ready to be attached to a swap.
+    """
 
     valuation_date: Date
     issue_date: Date
     maturity: Date
     currency: str
+    day_counter: DayCounter
     future_schedule: Schedule
+    nominal: float
 
+    def is_expired(self) -> bool:
+        return self.valuation_date >= self.maturity
+
+    @abstractmethod
+    def cashflows(self, **kwargs):  # pragma: no cover - thin wrapper
+        """Return the QuantLib cashflows for the leg."""
+        raise NotImplementedError
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class FixedLeg(SwapLeg):
-
     rate: float
 
+    def cashflows(self):
+        return FixedRateLeg(
             self.future_schedule,
             self.day_counter,
             [self.nominal],
@@ -34,12 +54,15 @@ class FixedLeg(SwapLeg):
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class FloatingLeg(SwapLeg):
-
     spread: float = 0.0
 
+    def cashflows(self, *, forecast_index: Index | None = None):
         if forecast_index is None:
+            raise ValueError("forecast_index is required for floating leg cashflows")
+        return IborLeg(
             [self.nominal],
             self.future_schedule,
             forecast_index,
             spreads=[self.spread],
+            paymentDayCounter=self.day_counter,
         )

--- a/pricingengine/instruments/__init__.py
+++ b/pricingengine/instruments/__init__.py
@@ -1,0 +1,15 @@
+"""Tradable financial instruments."""
+
+from ._instrument import Instrument
+from .interest_rate_swap import InterestRateSwap
+from .fx_forward import FXForward
+from .equity_option import EquityOption
+from .swaption import Swaption
+
+__all__ = [
+    "Instrument",
+    "InterestRateSwap",
+    "FXForward",
+    "EquityOption",
+    "Swaption",
+]

--- a/pricingengine/instruments/_instrument.py
+++ b/pricingengine/instruments/_instrument.py
@@ -4,7 +4,18 @@ from abc import ABC, abstractmethod
 
 
 class Instrument(ABC):
+    """Abstract base class for all tradable instruments."""
 
     @abstractmethod
+    def is_expired(self) -> bool:
+        """Whether the instrument has passed its maturity."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def mtm(self, *args, **kwargs) -> float:
+        """Mark-to-market value of the instrument."""
+        raise NotImplementedError
+
     def price(self, *args, **kwargs) -> float:
-        pass
+        """Convenience alias that delegates to :meth:`mtm`."""
+        return self.mtm(*args, **kwargs)

--- a/pricingengine/instruments/equity_option.py
+++ b/pricingengine/instruments/equity_option.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from QuantLib import (
+    Date,
+    SimpleQuote,
+    QuoteHandle,
+    FlatForward,
+    YieldTermStructureHandle,
+    BlackConstantVol,
+    BlackVolTermStructureHandle,
+    BlackScholesMertonProcess,
+    PlainVanillaPayoff,
+    Option,
+    EuropeanExercise,
+    VanillaOption,
+    AnalyticEuropeanEngine,
+    Actual365Fixed,
+    TARGET,
+)
+
+from pricingengine.instruments._instrument import Instrument
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class EquityOption(Instrument):
+    """Vanilla European equity option priced via Black--Scholes."""
+
+    valuation_date: Date
+    maturity: Date
+    option_type: str  # 'call' or 'put'
+    strike: float
+    spot: float
+    volatility: float  # absolute vol (e.g. 0.20)
+    risk_free_rate: float  # continuously compounded
+    dividend_rate: float = 0.0  # continuous dividend yield
+
+    def is_expired(self) -> bool:
+        return self.valuation_date >= self.maturity
+
+    def _option(
+        self,
+        *,
+        spot: float | None = None,
+        volatility: float | None = None,
+        risk_free_rate: float | None = None,
+        dividend_rate: float | None = None,
+    ) -> VanillaOption:
+        s = QuoteHandle(SimpleQuote(self.spot if spot is None else spot))
+        dc = Actual365Fixed()
+        r = self.risk_free_rate if risk_free_rate is None else risk_free_rate
+        q = self.dividend_rate if dividend_rate is None else dividend_rate
+        v = self.volatility if volatility is None else volatility
+        r_ts = YieldTermStructureHandle(FlatForward(self.valuation_date, r, dc))
+        q_ts = YieldTermStructureHandle(FlatForward(self.valuation_date, q, dc))
+        vol_ts = BlackVolTermStructureHandle(
+            BlackConstantVol(self.valuation_date, TARGET(), v, dc)
+        )
+        process = BlackScholesMertonProcess(s, q_ts, r_ts, vol_ts)
+        payoff = PlainVanillaPayoff(
+            Option.Call if self.option_type.lower() == "call" else Option.Put,
+            self.strike,
+        )
+        exercise = EuropeanExercise(self.maturity)
+        opt = VanillaOption(payoff, exercise)
+        opt.setPricingEngine(AnalyticEuropeanEngine(process))
+        return opt
+
+    def mtm(
+        self,
+        *,
+        spot: float | None = None,
+        volatility: float | None = None,
+        risk_free_rate: float | None = None,
+        dividend_rate: float | None = None,
+    ) -> float:
+        if self.is_expired():
+            return 0.0
+        return self._option(
+            spot=spot,
+            volatility=volatility,
+            risk_free_rate=risk_free_rate,
+            dividend_rate=dividend_rate,
+        ).NPV()
+
+    def delta(self, *, spot: float | None = None) -> float:
+        if self.is_expired():
+            return 0.0
+        return self._option(spot=spot).delta()
+
+    def gamma(self, *, spot: float | None = None) -> float:
+        if self.is_expired():
+            return 0.0
+        return self._option(spot=spot).gamma()
+
+    def vega(self, *, volatility: float | None = None) -> float:
+        if self.is_expired():
+            return 0.0
+        return self._option(volatility=volatility).vega()

--- a/pricingengine/instruments/fx_forward.py
+++ b/pricingengine/instruments/fx_forward.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from QuantLib import Date
+
+from pricingengine.instruments._instrument import Instrument
+from pricingengine.structures.curve_nodes import CurveNodes
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class FXForward(Instrument):
+    """Simple FX forward priced under interest-rate parity."""
+
+    valuation_date: Date
+    maturity: Date
+    notional: float  # foreign currency amount
+    forward_rate: float  # agreed domestic per unit foreign
+    spot: float  # current spot rate
+
+    def is_expired(self) -> bool:
+        return self.valuation_date >= self.maturity
+
+    def mtm(
+        self,
+        domestic_nodes: CurveNodes,
+        foreign_nodes: CurveNodes,
+        *,
+        spot: float | None = None,
+    ) -> float:
+        if self.is_expired():
+            return 0.0
+        s = self.spot if spot is None else spot
+        df_dom = domestic_nodes.discount_factor(self.maturity)
+        df_for = foreign_nodes.discount_factor(self.maturity)
+        fwd_mkt = s * df_for / df_dom
+        return self.notional * (fwd_mkt - self.forward_rate) * df_dom
+
+    def delta(self, foreign_nodes: CurveNodes) -> float:
+        """Sensitivity of PV to a change in the spot rate."""
+        if self.is_expired():
+            return 0.0
+        return self.notional * foreign_nodes.discount_factor(self.maturity)

--- a/pricingengine/instruments/interest_rate_swap.py
+++ b/pricingengine/instruments/interest_rate_swap.py
@@ -62,7 +62,6 @@ class InterestRateSwap(Instrument):
     def maturity(self):
         return self.receiving_leg.maturity
 
-    @property
     def is_expired(self) -> bool:
         return self.valuation_date >= self.maturity
 
@@ -128,7 +127,7 @@ class InterestRateSwap(Instrument):
 
     def mtm(self, forecast_index: Index, discount_nodes: CurveNodes) -> float:
         """Mark-to-market NPV of the swap."""
-        if self.is_expired:
+        if self.is_expired():
             return 0.0
         return self._swap_ql(forecast_index, discount_nodes).NPV()
 

--- a/pricingengine/instruments/swaption.py
+++ b/pricingengine/instruments/swaption.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from QuantLib import Date, Index, EuropeanExercise, Swaption as QLSwaption, BlackSwaptionEngine
+
+from pricingengine.instruments._instrument import Instrument
+from pricingengine.instruments.interest_rate_swap import InterestRateSwap
+from pricingengine.structures.curve_nodes import CurveNodes
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Swaption(Instrument):
+    """European swaption on a vanilla interest-rate swap."""
+
+    swap: InterestRateSwap
+    exercise_date: Date
+    volatility: float  # Black vol
+
+    def is_expired(self) -> bool:
+        return self.swap.valuation_date >= self.exercise_date
+
+    def _ql_swaption(
+        self,
+        forecast_index: Index,
+        discount_nodes: CurveNodes,
+        volatility: float,
+    ) -> QLSwaption:
+        vanilla = self.swap._vanilla_swap_ql(forecast_index, discount_nodes)
+        exercise = EuropeanExercise(self.exercise_date)
+        swpn = QLSwaption(vanilla, exercise)
+        engine = BlackSwaptionEngine(discount_nodes.to_handle(), volatility)
+        swpn.setPricingEngine(engine)
+        return swpn
+
+    def mtm(
+        self,
+        forecast_index: Index,
+        discount_nodes: CurveNodes,
+        *,
+        volatility: float | None = None,
+    ) -> float:
+        if self.is_expired():
+            return 0.0
+        v = self.volatility if volatility is None else volatility
+        return self._ql_swaption(forecast_index, discount_nodes, v).NPV()
+
+    def vega(
+        self,
+        forecast_index: Index,
+        discount_nodes: CurveNodes,
+        *,
+        volatility: float | None = None,
+    ) -> float:
+        if self.is_expired():
+            return 0.0
+        v = self.volatility if volatility is None else volatility
+        return self._ql_swaption(forecast_index, discount_nodes, v).vega()

--- a/pricingengine/irs.py
+++ b/pricingengine/irs.py
@@ -1,0 +1,5 @@
+"""Backward-compatible import for interest-rate swaps."""
+
+from .instruments.interest_rate_swap import InterestRateSwap
+
+__all__ = ["InterestRateSwap"]


### PR DESCRIPTION
## Summary
- Fix and flesh out `SwapLeg` hierarchy providing abstract base and concrete fixed/floating legs
- Introduce FX forward, equity option, and swaption instruments with appropriate pricing and risk methods
- Expose instruments via package `__init__` files and add backwards compatible `irs` alias

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7680abdfc832faea206699ad682d5