### PR TITLE
Expand curve node constructors and swaption features

### DIFF
--- a/pricingengine/instruments/swaption.py
+++ b/pricingengine/instruments/swaption.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional, Sequence
 
-from QuantLib import Date, Index, EuropeanExercise, Swaption as QLSwaption, BlackSwaptionEngine
+from QuantLib import (
+    BachelierSwaptionEngine,
+    BermudanExercise,
+    BlackSwaptionEngine,
+    Date,
+    EuropeanExercise,
+    Index,
+    Settlement,
+    Swaption as QLSwaption,
+    VanillaSwap,
+)
 
 from pricingengine.instruments._instrument import Instrument
 from pricingengine.instruments.interest_rate_swap import InterestRateSwap
@@ -11,48 +22,160 @@ from pricingengine.structures.curve_nodes import CurveNodes
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class Swaption(Instrument):
-    """European swaption on a vanilla interest-rate swap."""
+    """Vanilla swaption on a single-currency :class:`InterestRateSwap`."""
 
     swap: InterestRateSwap
-    exercise_date: Date
-    volatility: float  # Black vol
+    expiries: Optional[Sequence[Date]] = None
+    strike: Optional[float] = None
+    volatility: float = 0.01
+    vol_type: str = "black"  # "black" or "normal"
+    settlement: str = "physical"  # "physical" or "cash"
+    is_long: bool = True
 
-    def is_expired(self) -> bool:
-        return self.swap.valuation_date >= self.exercise_date
+    # ------------------------------------------------------------------
+    # convenience properties
+    @property
+    def valuation_date(self) -> Date:
+        return self.swap.valuation_date
 
-    def _ql_swaption(
+    @property
+    def currency(self):
+        return self.swap.currency
+
+    @property
+    def is_european(self) -> bool:
+        return len(self._expiries()) == 1
+
+    @property
+    def expiry(self) -> Date:
+        return self._expiries()[0]
+
+    def is_expired(self) -> bool:  # type: ignore[override]
+        return self.valuation_date >= self.expiry
+
+    # ------------------------------------------------------------------
+    # internals
+    def _expiries(self) -> Sequence[Date]:
+        if self.expiries and len(self.expiries) > 0:
+            return self.expiries
+        # default to swap start
+        return [self.swap.issue_date]
+
+    def _exercise(self):
+        exps = self._expiries()
+        if len(exps) == 1:
+            return EuropeanExercise(exps[0])
+        return BermudanExercise(list(exps))
+
+    def _settlement(self) -> Settlement:
+        return (
+            Settlement.Physical
+            if self.settlement.lower() == "physical"
+            else Settlement.Cash
+        )
+
+    def _vanilla_swap_for_pricing(
         self,
         forecast_index: Index,
         discount_nodes: CurveNodes,
-        volatility: float,
+        strike: Optional[float],
+    ) -> VanillaSwap:
+        """Build a :class:`VanillaSwap` for payoff evaluation."""
+        base = self.swap._vanilla_swap_ql(forecast_index, discount_nodes)
+        k = base.fairRate() if strike is None else float(strike)
+
+        if self.swap.fixed_leg is self.swap.paying_leg:
+            swap_type = VanillaSwap.Payer
+        else:
+            swap_type = VanillaSwap.Receiver
+
+        v = VanillaSwap(
+            swap_type,
+            self.swap.fixed_leg.nominal,
+            self.swap.fixed_leg.future_schedule,
+            k,
+            self.swap.fixed_leg.day_counter,
+            self.swap.floating_leg.future_schedule,
+            forecast_index,
+            self.swap.floating_leg.spread,
+            self.swap.floating_leg.day_counter,
+        )
+        v.setPricingEngine(self.swap._discount_engine(discount_nodes))
+        return v
+
+    def _engine(self, discount_nodes: CurveNodes):
+        dc = self.swap.fixed_leg.day_counter
+        handle = discount_nodes.to_handle()
+        vt = self.volatility
+        t = self.vol_type.lower()
+        if t == "black":
+            return BlackSwaptionEngine(handle, float(vt), dc)
+        if t in ("normal", "bachelier"):
+            return BachelierSwaptionEngine(handle, float(vt), dc)
+        raise ValueError("vol_type must be 'black' or 'normal'")
+
+    def _swaption(
+        self, forecast_index: Index, discount_nodes: CurveNodes
     ) -> QLSwaption:
-        vanilla = self.swap._vanilla_swap_ql(forecast_index, discount_nodes)
-        exercise = EuropeanExercise(self.exercise_date)
-        swpn = QLSwaption(vanilla, exercise)
-        engine = BlackSwaptionEngine(discount_nodes.to_handle(), volatility)
-        swpn.setPricingEngine(engine)
-        return swpn
+        vanilla = self._vanilla_swap_for_pricing(
+            forecast_index, discount_nodes, self.strike
+        )
+        swpt = QLSwaption(vanilla, self._exercise(), self._settlement())
+        swpt.setPricingEngine(self._engine(discount_nodes))
+        return swpt
 
-    def mtm(
-        self,
-        forecast_index: Index,
-        discount_nodes: CurveNodes,
-        *,
-        volatility: float | None = None,
+    # ------------------------------------------------------------------
+    # analytics
+    def mark_to_market(
+        self, forecast_index: Index, discount_nodes: CurveNodes
     ) -> float:
         if self.is_expired():
             return 0.0
-        v = self.volatility if volatility is None else volatility
-        return self._ql_swaption(forecast_index, discount_nodes, v).NPV()
+        v = self._swaption(forecast_index, discount_nodes).NPV()
+        return v if self.is_long else -v
 
-    def vega(
+    def mtm(self, forecast_index: Index, discount_nodes: CurveNodes) -> float:  # type: ignore[override]
+        return self.mark_to_market(forecast_index, discount_nodes)
+
+    def vega(self, forecast_index: Index, discount_nodes: CurveNodes) -> float:
+        if self.is_expired():
+            return 0.0
+        v = self._swaption(forecast_index, discount_nodes).vega()
+        return v if self.is_long else -v
+
+    def implied_volatility(
         self,
+        target_npv: float,
         forecast_index: Index,
         discount_nodes: CurveNodes,
         *,
-        volatility: float | None = None,
+        accuracy: float = 1e-7,
+        max_evaluations: int = 500,
+        min_vol: float = 1e-6,
+        max_vol: float = 5.0,
     ) -> float:
         if self.is_expired():
             return 0.0
-        v = self.volatility if volatility is None else volatility
-        return self._ql_swaption(forecast_index, discount_nodes, v).vega()
+        swpt = self._swaption(forecast_index, discount_nodes)
+        engine = self._engine(discount_nodes)
+        swpt.setPricingEngine(engine)
+        dc = self.swap.fixed_leg.day_counter
+        vol = swpt.impliedVolatility(
+            float(target_npv),
+            discount_nodes.to_handle(),
+            dc,
+            accuracy,
+            max_evaluations,
+            min_vol,
+            max_vol,
+        )
+        return float(vol)
+
+    def atm_strike(
+        self, forecast_index: Index, discount_nodes: CurveNodes
+    ) -> float:
+        v = self._vanilla_swap_for_pricing(
+            forecast_index, discount_nodes, None
+        )
+        return float(v.fairRate())
+

--- a/pricingengine/structures/curve_nodes.py
+++ b/pricingengine/structures/curve_nodes.py
@@ -216,3 +216,41 @@ class CurveNodes:
             quote_kind="discount",
             role=role,
         )
+
+    @classmethod
+    def from_forwards(
+        cls,
+        asof: Date,
+        dates: Sequence[Date],
+        forwards: Sequence[float],
+        day_count: DayCounter,
+        role: CurveRole = "forecasting",
+    ) -> CurveNodes:
+        """Convenience constructor for forward-rate curves."""
+        return cls(
+            asof=asof,
+            dates=dates,
+            quotes=forwards,
+            day_count=day_count,
+            quote_kind="forward",
+            role=role,
+        )
+
+    @classmethod
+    def from_flat(
+        cls,
+        asof: Date,
+        maturity: Date,
+        zero: float,
+        day_count: DayCounter,
+        role: CurveRole = "discounting",
+    ) -> CurveNodes:
+        """Flat zero-rate curve out to ``maturity``."""
+        return cls(
+            asof=asof,
+            dates=[maturity],
+            quotes=[zero],
+            day_count=day_count,
+            quote_kind="flat",
+            role=role,
+        )


### PR DESCRIPTION
## Summary
- add `from_forwards` and `from_flat` constructors for `CurveNodes`
- overhaul swaption instrument to support Bermudan/European exercises, settlement styles, vol types, long/short positions, and utility analytics

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76c59a878832f8c63ccf5eb144047