### PR TITLE
Fix curve caching and IR01 forecast implementation

### DIFF
--- a/.github/workflows/autofix-pr.yml
+++ b/.github/workflows/autofix-pr.yml
@@ -1,0 +1,31 @@
+name: autofix -> PR
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 3 * * 1"   # weekly, optional
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v1
+      - run: uv sync
+      - run: uv run ruff check . --fix
+      - run: uv run ruff format .  # if you use ruff fmt
+      - run: uv run black .
+      - run: uv run ruff check .
+      - run: uv run mypy src
+      - run: uv run pytest -q
+      - name: Create PR
+        if: ${{ success() }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: autofix/ruff-black
+          commit-message: "style: autofix (ruff/black)"
+          title: "Autofix: ruff/black"
+          body: "Automated fixes; CI is green."
+          labels: ci, autofix
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: CI
-
-on:
-  push:
-  pull_request:
-
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.5
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        args: [src]
+

--- a/pricingengine/examples/price_irs.py
+++ b/pricingengine/examples/price_irs.py
@@ -3,18 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
-from QuantLib import (
-    TARGET,
-    Actual365Fixed,
-    Date,
-    DateGeneration,
-    ModifiedFollowing,
-    Months,
-    Period,
-    Schedule,
-    Settings,
-    Years,
-)
+from QuantLib import TARGET, Actual365Fixed, Date, Months, Period, Settings, Years
 
 from pricingengine.cashflows.swap_leg import FixedLeg, FloatingLeg
 from pricingengine.indices.index_utils import make_forecast_index

--- a/pricingengine/instruments/interest_rate_swap.py
+++ b/pricingengine/instruments/interest_rate_swap.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
-from QuantLib import (DiscountingSwapEngine, Index, Swap, VanillaSwap, ZeroCurve)
 from dataclasses import dataclass
+from typing import Optional, Type, cast
+
 from pandas import DataFrame, merge, option_context
-from typing import Type, Optional
+from QuantLib import (
+    DiscountingSwapEngine,
+    Index,
+    QuoteHandle,
+    SimpleQuote,
+    Swap,
+    VanillaSwap,
+    YieldTermStructureHandle,
+    ZeroCurve,
+    ZeroSpreadedTermStructure,
+)
 
 from pricingengine.cashflows.swap_leg import FixedLeg, FloatingLeg, SwapLeg
 from pricingengine.instruments._instrument import Instrument
@@ -38,34 +49,50 @@ class InterestRateSwap(Instrument):
         t1, t2 = type(self.paying_leg), type(self.receiving_leg)
         # Type checks
         if not issubclass(t1, SwapLeg) or not issubclass(t2, SwapLeg):
-            raise ValueError("'paying_leg' and 'receiving_leg' must be a subclass of `SwapLeg`")
+            raise ValueError(
+                "'paying_leg' and 'receiving_leg' must be a subclass of `SwapLeg`"
+            )
         else:
             if issubclass(t1, FixedLeg) and issubclass(t2, FixedLeg):
-                raise ValueError("'paying_leg' and 'receiving_leg' cannot be of the same type `FixedLeg`")
+                raise ValueError(
+                    "'paying_leg' and 'receiving_leg' cannot be of the same type "
+                    "`FixedLeg`"
+                )
             elif issubclass(t1, FloatingLeg) and issubclass(t2, FloatingLeg):
-                raise ValueError("'paying_leg' and 'receiving_leg' cannot be of the same type `FloatingLeg`")
+                raise ValueError(
+                    "'paying_leg' and 'receiving_leg' cannot be of the same type "
+                    "`FloatingLeg`"
+                )
             else:
                 pass
         # Alignment checks
         if self.paying_leg.valuation_date != self.receiving_leg.valuation_date:
-            raise ValueError("'paying_leg' and 'receiving_leg' must have the same 'valuation_date'")
+            raise ValueError(
+                "'paying_leg' and 'receiving_leg' must have the same 'valuation_date'"
+            )
         elif self.paying_leg.issue_date != self.receiving_leg.issue_date:
-            raise ValueError("'paying_leg' and 'receiving_leg' must have the same 'issue_date'")
+            raise ValueError(
+                "'paying_leg' and 'receiving_leg' must have the same 'issue_date'"
+            )
         elif self.paying_leg.maturity != self.receiving_leg.maturity:
-            raise ValueError("'paying_leg' and 'receiving_leg' must have the same 'maturity'")
+            raise ValueError(
+                "'paying_leg' and 'receiving_leg' must have the same 'maturity'"
+            )
         elif self.paying_leg.currency != self.receiving_leg.currency:
-            raise ValueError("'paying_leg' and 'receiving_leg' must have the same 'currency'")
+            raise ValueError(
+                "'paying_leg' and 'receiving_leg' must have the same 'currency'"
+            )
         else:
             pass
 
     # ---------- properties ----------
     @property
     def fixed_leg(self) -> FixedLeg:
-        return self._leg(FixedLeg)
+        return cast(FixedLeg, self._leg(FixedLeg))
 
     @property
     def floating_leg(self) -> FloatingLeg:
-        return self._leg(FloatingLeg)
+        return cast(FloatingLeg, self._leg(FloatingLeg))
 
     @property
     def valuation_date(self):
@@ -103,16 +130,21 @@ class InterestRateSwap(Instrument):
         fl = self.floating_leg
         idx = getattr(fl, "index", None)  # FloatingLeg.index: Optional[Index]
         if idx is None:
-            raise ValueError("Missing forecasting Index: pass forecast_index=... or set floating_leg.index.")
+            raise ValueError(
+                "Missing forecasting Index: pass forecast_index=... "
+                "or set floating_leg.index."
+            )
         return idx
 
     @staticmethod
     def _discount_engine(discount_nodes: CurveNodes) -> DiscountingSwapEngine:
         """Build (or reuse) a discounting engine from CurveNodes."""
-        return DiscountingSwapEngine(discount_nodes.yts_handle())
+        return DiscountingSwapEngine(discount_nodes.yts_handle)
 
     # ---------- QL builders ----------
-    def _swap_ql(self, forecast_index: Optional[Index], discount_nodes: CurveNodes) -> Swap:
+    def _swap_ql(
+        self, forecast_index: Optional[Index], discount_nodes: CurveNodes
+    ) -> Swap:
         """
         Returns a QuantLib `Swap` object.
 
@@ -141,7 +173,9 @@ class InterestRateSwap(Instrument):
         swap.setPricingEngine(self._discount_engine(discount_nodes))
         return swap
 
-    def _vanilla_swap_ql(self, forecast_index: Optional[Index], discount_nodes: CurveNodes) -> VanillaSwap:
+    def _vanilla_swap_ql(
+        self, forecast_index: Optional[Index], discount_nodes: CurveNodes
+    ) -> VanillaSwap:
         """
         Returns a QuantLib `VanillaSwap` object.
 
@@ -161,15 +195,24 @@ class InterestRateSwap(Instrument):
         else:
             swap_type = VanillaSwap.Receiver
 
-        swap = VanillaSwap(swap_type, self.fixed_leg.nominal, self.fixed_leg.future_schedule, self.fixed_leg.rate,
-                           self.fixed_leg.day_counter, self.floating_leg.future_schedule, idx,
-                           self.floating_leg.spread,
-                           self.floating_leg.day_counter, )
+        swap = VanillaSwap(
+            swap_type,
+            self.fixed_leg.nominal,
+            self.fixed_leg.future_schedule,
+            self.fixed_leg.rate,
+            self.fixed_leg.day_counter,
+            self.floating_leg.future_schedule,
+            idx,
+            self.floating_leg.spread,
+            self.floating_leg.day_counter,
+        )
         swap.setPricingEngine(self._discount_engine(discount_nodes))
         return swap
 
     @staticmethod
-    def debug(swap: InterestRateSwap, forecast_index: Index, discount_nodes: CurveNodes) -> None:
+    def debug(
+        swap: InterestRateSwap, forecast_index: Index, discount_nodes: CurveNodes
+    ) -> None:
         """
         Display future payments for the swap, including the amounts payed,
         amounts received, net amounts, discount factors, and present values at
@@ -177,80 +220,122 @@ class InterestRateSwap(Instrument):
 
         The format is the same as in Bloomberg Terminal SWPM function.
         """
-        swap_ql = swap._swap_ql(forecast_index=forecast_index, discount_nodes=discount_nodes)
+        swap_ql = swap._swap_ql(
+            forecast_index=forecast_index, discount_nodes=discount_nodes
+        )
 
-        discount_curve_ql = ZeroCurve(discount_nodes.dates, discount_nodes.quotes, discount_nodes.day_counter)
+        discount_curve_ql = ZeroCurve(
+            discount_nodes.dates, discount_nodes.quotes, discount_nodes.day_counter
+        )
 
-        df_pay = DataFrame(data=({"Date": c.date(), "Pay": -c.amount()} for c in swap_ql.leg(0)))
-        df_receive = DataFrame(data=({"Date": c.date(), "Receive": c.amount()} for c in swap_ql.leg(1)))
+        df_pay = DataFrame(
+            data=({"Date": c.date(), "Pay": -c.amount()} for c in swap_ql.leg(0))
+        )
+        df_receive = DataFrame(
+            data=({"Date": c.date(), "Receive": c.amount()} for c in swap_ql.leg(1))
+        )
 
-        df = (merge(df_pay, df_receive, how="outer", on="Date", sort=True)
-              .fillna(0)  # when schedules in the swap are different
-              .assign(Net=lambda x: x.Pay + x.Receive,
-                      DiscountFactor=lambda x: x.Date.apply(discount_curve_ql.discount),
-                      PresentValue=lambda x: x.Net * x.DiscountFactor,
-                      Date=lambda x: x.Date.apply(lambda date: date.ISO()), )
-              .rename(columns={"Pay": f"Pay ({swap.paying_leg.__class__.__name__})",
-                               "Receive": f"Receive ({swap.receiving_leg.__class__.__name__})", })
-              .set_index("Date"))
+        df = (
+            merge(df_pay, df_receive, how="outer", on="Date", sort=True)
+            .fillna(0)  # when schedules in the swap are different
+            .assign(
+                Net=lambda x: x.Pay + x.Receive,
+                DiscountFactor=lambda x: x.Date.apply(discount_curve_ql.discount),
+                PresentValue=lambda x: x.Net * x.DiscountFactor,
+                Date=lambda x: x.Date.apply(lambda date: date.ISO()),
+            )
+            .rename(
+                columns={
+                    "Pay": f"Pay ({swap.paying_leg.__class__.__name__})",
+                    "Receive": f"Receive ({swap.receiving_leg.__class__.__name__})",
+                }
+            )
+            .set_index("Date")
+        )
 
         with option_context("display.float_format", "{:,.2f}".format):
             df["DiscountFactor"] = df.DiscountFactor.map("{:,.6f}".format)
             print(df)
 
-    def getCashFlows(self, forecast_index: Index, discount_nodes: CurveNodes) -> DataFrame:
-        swap_ql = self._swap_ql(forecast_index=forecast_index, discount_nodes=discount_nodes)
+    def getCashFlows(
+        self, forecast_index: Index, discount_nodes: CurveNodes
+    ) -> DataFrame:
+        swap_ql = self._swap_ql(
+            forecast_index=forecast_index, discount_nodes=discount_nodes
+        )
 
-        discount_curve_ql = ZeroCurve(discount_nodes.dates, discount_nodes.quotes, discount_nodes.day_counter)
+        discount_curve_ql = ZeroCurve(
+            discount_nodes.dates, discount_nodes.quotes, discount_nodes.day_counter
+        )
 
-        df_pay = DataFrame(data=({"Date": c.date(), "Pay": -c.amount()} for c in swap_ql.leg(0)))
-        df_receive = DataFrame(data=({"Date": c.date(), "Receive": c.amount()} for c in swap_ql.leg(1)))
+        df_pay = DataFrame(
+            data=({"Date": c.date(), "Pay": -c.amount()} for c in swap_ql.leg(0))
+        )
+        df_receive = DataFrame(
+            data=({"Date": c.date(), "Receive": c.amount()} for c in swap_ql.leg(1))
+        )
 
-        df = (merge(df_pay, df_receive, how="outer", on="Date", sort=True)
-              .fillna(0)  # when schedules in the swap are different
-              .assign(Net=lambda x: x.Pay + x.Receive,
-                      DiscountFactor=lambda x: x.Date.apply(discount_curve_ql.discount),
-                      PresentValue=lambda x: x.Net * x.DiscountFactor,
-                      Date=lambda x: x.Date.apply(lambda date: date.ISO()), )
-              .rename(columns={"Pay": f"Pay ({self.paying_leg.__class__.__name__})",
-                               "Receive": f"Receive ({self.receiving_leg.__class__.__name__})", })
-              .set_index("Date"))
+        df = (
+            merge(df_pay, df_receive, how="outer", on="Date", sort=True)
+            .fillna(0)  # when schedules in the swap are different
+            .assign(
+                Net=lambda x: x.Pay + x.Receive,
+                DiscountFactor=lambda x: x.Date.apply(discount_curve_ql.discount),
+                PresentValue=lambda x: x.Net * x.DiscountFactor,
+                Date=lambda x: x.Date.apply(lambda date: date.ISO()),
+            )
+            .rename(
+                columns={
+                    "Pay": f"Pay ({self.paying_leg.__class__.__name__})",
+                    "Receive": f"Receive ({self.receiving_leg.__class__.__name__})",
+                }
+            )
+            .set_index("Date")
+        )
         return df
 
-    def mark_to_market(self, discount_nodes: CurveNodes, forecast_index: Optional[Index] = None) -> float:
+    def mark_to_market(
+        self, discount_nodes: CurveNodes, forecast_index: Optional[Index] = None
+    ) -> float:
         """Returns mark-to-market value of the swap."""
         if self.is_expired:
             return 0.0
         else:
-            return self._swap_ql(forecast_index=forecast_index, discount_nodes=discount_nodes).NPV()
+            return self._swap_ql(
+                forecast_index=forecast_index, discount_nodes=discount_nodes
+            ).NPV()
 
-    def mtm(self, forecast_index: Optional[Index], discount_nodes: CurveNodes) -> float:  # pragma: no cover - simple alias
+    def mtm(
+        self, forecast_index: Optional[Index], discount_nodes: CurveNodes
+    ) -> float:  # pragma: no cover - simple alias
         """Alias to satisfy Instrument interface."""
-        return self.mark_to_market(discount_nodes=discount_nodes, forecast_index=forecast_index)
+        return self.mark_to_market(
+            discount_nodes=discount_nodes, forecast_index=forecast_index
+        )
 
     def pv01(
-            self,
-            discount_nodes: CurveNodes,
-            forecast_index: Optional[Index] = None,
+        self,
+        discount_nodes: CurveNodes,
+        forecast_index: Optional[Index] = None,
     ) -> float:
         """Fixed-leg PV01 (coupon BPV): NPV change for +1 bp in the fixed coupon."""
         leg_index = 0 if (self.fixed_leg is self.paying_leg) else 1
         return self._swap_ql(forecast_index, discount_nodes).legBPS(leg_index)
 
     def dv01(
-            self,
-            discount_nodes: CurveNodes,
-            forecast_index: Optional[Index] = None,
+        self,
+        discount_nodes: CurveNodes,
+        forecast_index: Optional[Index] = None,
     ) -> float:
         """Floating-leg BPV to spread: NPV change for +1 bp in the floating spread."""
         leg_index = 0 if (self.floating_leg is self.paying_leg) else 1
         return self._swap_ql(forecast_index, discount_nodes).legBPS(leg_index)
 
     def ir01_discount(
-            self,
-            discount_nodes: CurveNodes,
-            forecast_index: Optional[Index] = None,
-            bump_bp: float = 1.0,
+        self,
+        discount_nodes: CurveNodes,
+        forecast_index: Optional[Index] = None,
+        bump_bp: float = 1.0,
     ) -> float:
         """
         Curve BPV to a parallel bump of the *discounting* curve.
@@ -262,19 +347,21 @@ class InterestRateSwap(Instrument):
         return (bumped - base) / bump_bp
 
     def ir01_forecast(
-            self,
-            forecast_nodes: CurveNodes,
-            discount_nodes: CurveNodes,
-            base_index: Optional[Index] = None,
-            bump_bp: float = 1.0,
+        self,
+        discount_nodes: CurveNodes,
+        forecast_index: Optional[Index] = None,
+        bump_bp: float = 1.0,
     ) -> float:
-        """
-        Curve BPV to a parallel bump of the *forecasting* (index) curve.
-        """
-        # resolve the base index (either provided or bound to the leg)
-        idx0 = self._resolve_index(base_index)
-        # build bumped forecasting handle and clone the index on it
-        idx_bumped = idx0.clone(forecast_nodes.bump(bump_bp).yts_handle())
-        base = self._swap_ql(idx0, discount_nodes).NPV()
-        bumped = self._swap_ql(idx_bumped, discount_nodes).NPV()
-        return (bumped - base) / bump_bp
+        """Curve BPV to a +bp parallel shift of the *forecasting* curve currently
+        on the index."""
+        idx = self._resolve_index(forecast_index)
+        base_handle = idx.forwardingTermStructure()
+
+        bump_r = bump_bp / 10_000.0
+        spread_q = SimpleQuote(bump_r)
+        bumped_ts = ZeroSpreadedTermStructure(base_handle, QuoteHandle(spread_q))
+        idx_bumped = idx.clone(YieldTermStructureHandle(bumped_ts))
+
+        pv0 = self._swap_ql(idx, discount_nodes).NPV()
+        pv1 = self._swap_ql(idx_bumped, discount_nodes).NPV()
+        return (pv1 - pv0) / bump_bp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "QuantLib>=1.27",
+    "pandas>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_curve_nodes.py
+++ b/tests/test_curve_nodes.py
@@ -16,12 +16,12 @@ def test_flat_curve_discount_and_bump() -> None:
         day_counter=dc,
         quote_kind="flat",
     )
-    d = nodes.yts_handle().discount(as_of + ql.Period(5, ql.Years))
+    d = nodes.yts_handle.discount(as_of + ql.Period(5, ql.Years))
     t = dc.yearFraction(as_of, as_of + ql.Period(5, ql.Years))
     assert abs(d - math.exp(-0.02 * t)) < 1e-9
 
     bumped = nodes.bump(1.0)
-    d_b = bumped.yts_handle().discount(as_of + ql.Period(5, ql.Years))
+    d_b = bumped.yts_handle.discount(as_of + ql.Period(5, ql.Years))
     assert abs(d_b - math.exp(-(0.02 + 0.0001) * t)) < 1e-9
 
 


### PR DESCRIPTION
## Summary
- avoid leaking cached handles across bumped CurveNodes by using `cached_property`
- compute forecast curve IR01 via spreaded term structure
- clean up swap leg utilities and demo imports for repo-wide lint compliance
- add GitHub workflows and pre-commit configuration for linting and tests
- declare `pandas` runtime dependency for swap leg utilities

## Testing
- `uv run ruff check .`
- `uv run black --check .`
- `uv run mypy src`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b88b333f7c832f88df55e448e63949