### PR TITLE
docs: expand README and fix Makefile tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,19 @@ PY = uv run python
 .PHONY: setup format lint test run-example
 
 setup:
-        uv venv
-        uv sync
+	uv venv
+	uv sync
 
 format:
-        uv run black .
+	uv run black .
 
 lint:
-        uv run ruff check .
-        uv run black --check .
-        uv run mypy pricingengine
+	uv run ruff check .
+	uv run black --check .
+	uv run mypy pricingengine
 
 test:
-        uv run pytest -q
+	uv run pytest -q
 
 run-example:
 	uv run python -m pricingengine.examples.price_irs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,42 @@
 # PricingEngine
 
+PricingEngine is a Python library for pricing basic financial instruments on top of [QuantLib](https://www.quantlib.org/). It provides building blocks for term structures, cash flows and instruments so you can prototype analytic valuations.
 
-Financial instrument engine using QuantLib.
+## Features
 
-  Made With Love <3
+- Curve representation through `CurveNodes` for discounting and forecasting.
+- Cash flow modeling of fixed and floating legs.
+- Instruments including interest rate swaps, FX forwards, swaptions and equity options.
+- Helpers to compute MTM, PV01/DV01 and cash flow tables.
+
+## Installation
+
+This project targets Python 3.11+. Install the package and test dependencies with:
+
+```bash
+pip install -e .[test]
+```
+
+## Example
+
+Run the built-in example to price a vanilla interest rate swap:
+
+```bash
+python -m pricingengine.examples.price_irs
+```
+
+The script builds flat discount and forecast curves, calculates MTM and PV01 and prints the cash-flow schedule.
+
+## Development
+
+Formatting and linting are managed via `ruff`, `black` and `mypy`. Helpful `make` targets:
+
+```bash
+make format   # format code
+make lint     # ruff, black --check and mypy
+make test     # run pytest
+```
+
+## License
+
+Made With Love <3


### PR DESCRIPTION
## Summary
- document features, installation, example and development workflow in README
- use tabs in Makefile so `make lint` and other targets work

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b8dde38460832f833e7131ddc91c62