### PR TITLE
Refactor swap legs and IRS to use curve handles

### DIFF
--- a/pricingengine/cashflows/swap_leg.py
+++ b/pricingengine/cashflows/swap_leg.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, replace
 from functools import cached_property
 from typing import cast
 
-from pandas import DataFrame, option_context
 from QuantLib import (
     Calendar,
     CashFlow,
@@ -21,6 +20,7 @@ from QuantLib import (
     as_coupon,
     as_floating_rate_coupon,
 )
+from pandas import DataFrame, option_context
 
 from pricingengine.currencies import CURRENCIES
 

--- a/pricingengine/cashflows/swap_leg.py
+++ b/pricingengine/cashflows/swap_leg.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, replace
 from functools import cached_property
 from typing import cast
 
+from pandas import DataFrame, option_context
 from QuantLib import (
     Calendar,
     CashFlow,
@@ -20,7 +21,6 @@ from QuantLib import (
     as_coupon,
     as_floating_rate_coupon,
 )
-from pandas import DataFrame, option_context
 
 from pricingengine.currencies import CURRENCIES
 

--- a/pricingengine/instruments/interest_rate_swap.py
+++ b/pricingengine/instruments/interest_rate_swap.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional, Type, cast
-
-from pandas import DataFrame, merge, option_context
 from QuantLib import (
     DiscountingSwapEngine,
     Index,
-    QuoteHandle,
-    SimpleQuote,
     Swap,
     VanillaSwap,
     YieldTermStructureHandle,
-    ZeroCurve,
+    QuoteHandle,
+    SimpleQuote,
     ZeroSpreadedTermStructure,
+    Continuous,
+    Annual,
 )
+from dataclasses import dataclass
+from functools import cached_property
+from pandas import DataFrame, merge, option_context
+from typing import Optional, Type
 
 from pricingengine.cashflows.swap_leg import FixedLeg, FloatingLeg, SwapLeg
 from pricingengine.instruments._instrument import Instrument
@@ -43,56 +44,41 @@ class InterestRateSwap(Instrument):
 
     paying_leg: FixedLeg | FloatingLeg
     receiving_leg: FixedLeg | FloatingLeg
+    discount_curve: YieldTermStructureHandle  # required; can be Relinkable
 
     # ---------- lifecycle & invariants ----------
     def __post_init__(self):
         t1, t2 = type(self.paying_leg), type(self.receiving_leg)
         # Type checks
         if not issubclass(t1, SwapLeg) or not issubclass(t2, SwapLeg):
-            raise ValueError(
-                "'paying_leg' and 'receiving_leg' must be a subclass of `SwapLeg`"
-            )
+            raise ValueError("'paying_leg' and 'receiving_leg' must be a subclass of `SwapLeg`")
         else:
             if issubclass(t1, FixedLeg) and issubclass(t2, FixedLeg):
-                raise ValueError(
-                    "'paying_leg' and 'receiving_leg' cannot be of the same type "
-                    "`FixedLeg`"
-                )
+                raise ValueError("'paying_leg' and 'receiving_leg' cannot be of the same type `FixedLeg`")
             elif issubclass(t1, FloatingLeg) and issubclass(t2, FloatingLeg):
-                raise ValueError(
-                    "'paying_leg' and 'receiving_leg' cannot be of the same type "
-                    "`FloatingLeg`"
-                )
+                raise ValueError("'paying_leg' and 'receiving_leg' cannot be of the same type `FloatingLeg`")
             else:
                 pass
         # Alignment checks
         if self.paying_leg.valuation_date != self.receiving_leg.valuation_date:
-            raise ValueError(
-                "'paying_leg' and 'receiving_leg' must have the same 'valuation_date'"
-            )
+            raise ValueError("'paying_leg' and 'receiving_leg' must have the same 'valuation_date'")
         elif self.paying_leg.issue_date != self.receiving_leg.issue_date:
-            raise ValueError(
-                "'paying_leg' and 'receiving_leg' must have the same 'issue_date'"
-            )
+            raise ValueError("'paying_leg' and 'receiving_leg' must have the same 'issue_date'")
         elif self.paying_leg.maturity != self.receiving_leg.maturity:
-            raise ValueError(
-                "'paying_leg' and 'receiving_leg' must have the same 'maturity'"
-            )
+            raise ValueError("'paying_leg' and 'receiving_leg' must have the same 'maturity'")
         elif self.paying_leg.currency != self.receiving_leg.currency:
-            raise ValueError(
-                "'paying_leg' and 'receiving_leg' must have the same 'currency'"
-            )
+            raise ValueError("'paying_leg' and 'receiving_leg' must have the same 'currency'")
         else:
             pass
 
     # ---------- properties ----------
     @property
     def fixed_leg(self) -> FixedLeg:
-        return cast(FixedLeg, self._leg(FixedLeg))
+        return self._leg(FixedLeg)
 
     @property
     def floating_leg(self) -> FloatingLeg:
-        return cast(FloatingLeg, self._leg(FloatingLeg))
+        return self._leg(FloatingLeg)
 
     @property
     def valuation_date(self):
@@ -114,6 +100,12 @@ class InterestRateSwap(Instrument):
     def is_expired(self):
         return self.valuation_date >= self.maturity
 
+    # ---------- discounting engine ----------
+    @cached_property
+    def discount_engine(self) -> DiscountingSwapEngine:
+        # Works with relinkable handles transparently
+        return DiscountingSwapEngine(self.discount_curve)
+
     # ---------- internals ----------
     def _leg(self, cls: Type[SwapLeg]) -> FixedLeg | FloatingLeg:
         """Return the leg of the requested class; error if missing."""
@@ -123,28 +115,7 @@ class InterestRateSwap(Instrument):
             return self.paying_leg
         raise RuntimeError(f"swap is missing {cls.__name__}")
 
-    def _resolve_index(self, forecast_index: Optional[Index]) -> Index:
-        if forecast_index is not None:
-            return forecast_index
-        # use the leg’s bound index if available
-        fl = self.floating_leg
-        idx = getattr(fl, "index", None)  # FloatingLeg.index: Optional[Index]
-        if idx is None:
-            raise ValueError(
-                "Missing forecasting Index: pass forecast_index=... "
-                "or set floating_leg.index."
-            )
-        return idx
-
-    @staticmethod
-    def _discount_engine(discount_nodes: CurveNodes) -> DiscountingSwapEngine:
-        """Build (or reuse) a discounting engine from CurveNodes."""
-        return DiscountingSwapEngine(discount_nodes.yts_handle)
-
-    # ---------- QL builders ----------
-    def _swap_ql(
-        self, forecast_index: Optional[Index], discount_nodes: CurveNodes
-    ) -> Swap:
+    def _swap_ql(self) -> Swap:
         """
         Returns a QuantLib `Swap` object.
 
@@ -157,25 +128,13 @@ class InterestRateSwap(Instrument):
 
         This method is a part of valuation framework for IRS.
         """
-        idx = self._resolve_index(forecast_index)
+        pay = self.paying_leg.cashflows
+        rec = self.receiving_leg.cashflows
+        sw = Swap(pay, rec)
+        sw.setPricingEngine(self.discount_engine)
+        return sw
 
-        if isinstance(self.paying_leg, FixedLeg):
-            paying_leg = self.paying_leg.cashflows()
-        else:  # must be FloatingLeg by invariant
-            paying_leg = self.paying_leg.cashflows(forecast_index=idx)
-
-        if isinstance(self.receiving_leg, FixedLeg):
-            receiving_leg = self.receiving_leg.cashflows()
-        else:  # must be FloatingLeg by invariant
-            receiving_leg = self.receiving_leg.cashflows(forecast_index=idx)
-
-        swap = Swap(paying_leg, receiving_leg)
-        swap.setPricingEngine(self._discount_engine(discount_nodes))
-        return swap
-
-    def _vanilla_swap_ql(
-        self, forecast_index: Optional[Index], discount_nodes: CurveNodes
-    ) -> VanillaSwap:
+    def _vanilla_swap_ql(self) -> VanillaSwap:
         """
         Returns a QuantLib `VanillaSwap` object.
 
@@ -188,101 +147,115 @@ class InterestRateSwap(Instrument):
         `VanillaSwap` object also includes `fairRate` and `fairSpread` methods
         and is therefore used for construction and valuation of swaptions.
         """
-        idx = self._resolve_index(forecast_index)
-
-        if self.fixed_leg is self.paying_leg:
-            swap_type = VanillaSwap.Payer
-        else:
-            swap_type = VanillaSwap.Receiver
-
-        swap = VanillaSwap(
+        swap_type = VanillaSwap.Payer if (self.fixed_leg is self.paying_leg) else VanillaSwap.Receiver
+        vs = VanillaSwap(
             swap_type,
             self.fixed_leg.nominal,
             self.fixed_leg.future_schedule,
             self.fixed_leg.rate,
             self.fixed_leg.day_counter,
             self.floating_leg.future_schedule,
-            idx,
+            self.floating_leg.index,  # index already bound to its (relinkable) handle
             self.floating_leg.spread,
             self.floating_leg.day_counter,
         )
-        swap.setPricingEngine(self._discount_engine(discount_nodes))
-        return swap
+        vs.setPricingEngine(self.discount_engine)
+        return vs
 
-    @staticmethod
-    def debug(
-        swap: InterestRateSwap, forecast_index: Index, discount_nodes: CurveNodes
-    ) -> None:
+    # ---------- analytics ----------
+    def mark_to_market(self) -> float:
+        if self.is_expired:
+            return 0.0
+        return self._swap_ql().NPV()
+
+    def mtm(self) -> float:  # pragma: no cover - simple alias
+        """Alias to satisfy Instrument interface."""
+        return self.mark_to_market()
+
+    def pv01(self) -> float:
+        """Fixed-leg PV01 (coupon BPV): ΔNPV for +1 bp in the fixed coupon."""
+        leg_index = 0 if (self.fixed_leg is self.paying_leg) else 1
+        return self._swap_ql().legBPS(leg_index)
+
+    def dv01(self) -> float:
+        """Floating-leg BPV to spread: ΔNPV for +1 bp in the floating spread."""
+        leg_index = 0 if (self.floating_leg is self.paying_leg) else 1
+        return self._swap_ql().legBPS(leg_index)
+
+    def ir01_discount(self, bump_bp: float = 1.0) -> float:
         """
-        Display future payments for the swap, including the amounts payed,
-        amounts received, net amounts, discount factors, and present values at
-        each payment date.
-
-        The format is the same as in Bloomberg Terminal SWPM function.
+        Curve BPV to a parallel bump of the *discounting* curve (in zero-yield terms).
+        Positive means NPV rises when discount rates fall.
         """
-        swap_ql = swap._swap_ql(
-            forecast_index=forecast_index, discount_nodes=discount_nodes
-        )
+        base = self._swap_ql().NPV()
 
-        discount_curve_ql = ZeroCurve(
-            discount_nodes.dates, discount_nodes.quotes, discount_nodes.day_counter
+        # Build a spreaded curve on top of the current discount handle.
+        spread = QuoteHandle(SimpleQuote(bump_bp / 10_000.0))
+        bumped_ts = ZeroSpreadedTermStructure(
+            self.discount_curve,  # Handle<YTS>
+            spread,
+            Continuous,  # bump in continuous zero-yield space
+            Annual,  # unused with Continuous, but required by ctor
+            self.discount_curve.dayCounter(),
         )
+        bumped_engine = DiscountingSwapEngine(YieldTermStructureHandle(bumped_ts))
 
-        df_pay = DataFrame(
-            data=({"Date": c.date(), "Pay": -c.amount()} for c in swap_ql.leg(0))
-        )
-        df_receive = DataFrame(
-            data=({"Date": c.date(), "Receive": c.amount()} for c in swap_ql.leg(1))
-        )
+        # Rebuild a Swap with the bumped engine (legs are identical).
+        pay = self.paying_leg.cashflows
+        rec = self.receiving_leg.cashflows
+        sw_bumped = Swap(pay, rec)
+        sw_bumped.setPricingEngine(bumped_engine)
 
+        bumped = sw_bumped.NPV()
+        return (bumped - base) / bump_bp
+
+    def ir01_forecast(self, bump_bp: float = 1.0) -> float:
+        """
+        Curve BPV to a parallel bump of the *forecasting* (index) curve.
+        Uses the floating leg's IborIndex forwarding handle; no external nodes.
+        """
+        base = self._swap_ql().NPV()
+
+        # Bump the index's forwarding TS via a zero-spread wrapper.
+        idx0 = self.floating_leg.index
+        fwd_handle = idx0.forwardingTermStructure()  # Handle<YTS>
+        spread = QuoteHandle(SimpleQuote(bump_bp / 10_000.0))
+        bumped_fwd_ts = ZeroSpreadedTermStructure(
+            fwd_handle,           # Handle<YTS>
+            spread,
+            Continuous,
+            Annual,
+            fwd_handle.dayCounter(),
+        )
+        idx_bumped = idx0.clone(YieldTermStructureHandle(bumped_fwd_ts))
+
+        # Rebuild the floating leg with the bumped index so cashflows bind to it.
+        fl_bumped = self.floating_leg.with_index(idx_bumped)
+        pay_b = fl_bumped.cashflows if (self.floating_leg is self.paying_leg) else self.paying_leg.cashflows
+        rec_b = fl_bumped.cashflows if (self.floating_leg is self.receiving_leg) else self.receiving_leg.cashflows
+
+        sw_bumped = Swap(pay_b, rec_b)
+        sw_bumped.setPricingEngine(self.discount_engine)  # same discounting
+        bumped = sw_bumped.NPV()
+
+        return (bumped - base) / bump_bp
+
+    # ---------- diagnostics ----------
+    def cashflow_table(self) -> DataFrame:
+        """Bloomberg-style cashflow breakdown using the bound discount curve."""
+        sw = self._swap_ql()
+        df_pay = DataFrame(data=({"Date": c.date(), "Pay": -c.amount()} for c in sw.leg(0)))
+        df_rec = DataFrame(data=({"Date": c.date(), "Receive": c.amount()} for c in sw.leg(1)))
+
+        h = self.discount_curve
         df = (
-            merge(df_pay, df_receive, how="outer", on="Date", sort=True)
-            .fillna(0)  # when schedules in the swap are different
+            merge(df_pay, df_rec, how="outer", on="Date", sort=True)
+            .fillna(0.0)
             .assign(
                 Net=lambda x: x.Pay + x.Receive,
-                DiscountFactor=lambda x: x.Date.apply(discount_curve_ql.discount),
+                DiscountFactor=lambda x: x.Date.apply(h.discount),
                 PresentValue=lambda x: x.Net * x.DiscountFactor,
-                Date=lambda x: x.Date.apply(lambda date: date.ISO()),
-            )
-            .rename(
-                columns={
-                    "Pay": f"Pay ({swap.paying_leg.__class__.__name__})",
-                    "Receive": f"Receive ({swap.receiving_leg.__class__.__name__})",
-                }
-            )
-            .set_index("Date")
-        )
-
-        with option_context("display.float_format", "{:,.2f}".format):
-            df["DiscountFactor"] = df.DiscountFactor.map("{:,.6f}".format)
-            print(df)
-
-    def getCashFlows(
-        self, forecast_index: Index, discount_nodes: CurveNodes
-    ) -> DataFrame:
-        swap_ql = self._swap_ql(
-            forecast_index=forecast_index, discount_nodes=discount_nodes
-        )
-
-        discount_curve_ql = ZeroCurve(
-            discount_nodes.dates, discount_nodes.quotes, discount_nodes.day_counter
-        )
-
-        df_pay = DataFrame(
-            data=({"Date": c.date(), "Pay": -c.amount()} for c in swap_ql.leg(0))
-        )
-        df_receive = DataFrame(
-            data=({"Date": c.date(), "Receive": c.amount()} for c in swap_ql.leg(1))
-        )
-
-        df = (
-            merge(df_pay, df_receive, how="outer", on="Date", sort=True)
-            .fillna(0)  # when schedules in the swap are different
-            .assign(
-                Net=lambda x: x.Pay + x.Receive,
-                DiscountFactor=lambda x: x.Date.apply(discount_curve_ql.discount),
-                PresentValue=lambda x: x.Net * x.DiscountFactor,
-                Date=lambda x: x.Date.apply(lambda date: date.ISO()),
+                Date=lambda x: x.Date.apply(lambda d: d.ISO()),
             )
             .rename(
                 columns={
@@ -292,76 +265,7 @@ class InterestRateSwap(Instrument):
             )
             .set_index("Date")
         )
+        with option_context("display.float_format", "{:,.2f}".format):
+            df["DiscountFactor"] = df.DiscountFactor.map("{:,.6f}".format)
         return df
 
-    def mark_to_market(
-        self, discount_nodes: CurveNodes, forecast_index: Optional[Index] = None
-    ) -> float:
-        """Returns mark-to-market value of the swap."""
-        if self.is_expired:
-            return 0.0
-        else:
-            return self._swap_ql(
-                forecast_index=forecast_index, discount_nodes=discount_nodes
-            ).NPV()
-
-    def mtm(
-        self, forecast_index: Optional[Index], discount_nodes: CurveNodes
-    ) -> float:  # pragma: no cover - simple alias
-        """Alias to satisfy Instrument interface."""
-        return self.mark_to_market(
-            discount_nodes=discount_nodes, forecast_index=forecast_index
-        )
-
-    def pv01(
-        self,
-        discount_nodes: CurveNodes,
-        forecast_index: Optional[Index] = None,
-    ) -> float:
-        """Fixed-leg PV01 (coupon BPV): NPV change for +1 bp in the fixed coupon."""
-        leg_index = 0 if (self.fixed_leg is self.paying_leg) else 1
-        return self._swap_ql(forecast_index, discount_nodes).legBPS(leg_index)
-
-    def dv01(
-        self,
-        discount_nodes: CurveNodes,
-        forecast_index: Optional[Index] = None,
-    ) -> float:
-        """Floating-leg BPV to spread: NPV change for +1 bp in the floating spread."""
-        leg_index = 0 if (self.floating_leg is self.paying_leg) else 1
-        return self._swap_ql(forecast_index, discount_nodes).legBPS(leg_index)
-
-    def ir01_discount(
-        self,
-        discount_nodes: CurveNodes,
-        forecast_index: Optional[Index] = None,
-        bump_bp: float = 1.0,
-    ) -> float:
-        """
-        Curve BPV to a parallel bump of the *discounting* curve.
-        Positive means NPV rises when discount rates fall.
-        """
-        base = self._swap_ql(forecast_index, discount_nodes).NPV()
-        bumped_nodes = discount_nodes.bump(bump_bp)
-        bumped = self._swap_ql(forecast_index, bumped_nodes).NPV()
-        return (bumped - base) / bump_bp
-
-    def ir01_forecast(
-        self,
-        discount_nodes: CurveNodes,
-        forecast_index: Optional[Index] = None,
-        bump_bp: float = 1.0,
-    ) -> float:
-        """Curve BPV to a +bp parallel shift of the *forecasting* curve currently
-        on the index."""
-        idx = self._resolve_index(forecast_index)
-        base_handle = idx.forwardingTermStructure()
-
-        bump_r = bump_bp / 10_000.0
-        spread_q = SimpleQuote(bump_r)
-        bumped_ts = ZeroSpreadedTermStructure(base_handle, QuoteHandle(spread_q))
-        idx_bumped = idx.clone(YieldTermStructureHandle(bumped_ts))
-
-        pv0 = self._swap_ql(idx, discount_nodes).NPV()
-        pv1 = self._swap_ql(idx_bumped, discount_nodes).NPV()
-        return (pv1 - pv0) / bump_bp

--- a/pricingengine/instruments/interest_rate_swap.py
+++ b/pricingengine/instruments/interest_rate_swap.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Type, cast
 
-from pandas import DataFrame, merge, option_context
 from QuantLib import (
     Annual,
     Continuous,
@@ -16,6 +15,7 @@ from QuantLib import (
     YieldTermStructureHandle,
     ZeroSpreadedTermStructure,
 )
+from pandas import DataFrame, merge, option_context
 
 from pricingengine.cashflows.swap_leg import FixedLeg, FloatingLeg, SwapLeg
 from pricingengine.instruments._instrument import Instrument

--- a/pricingengine/instruments/interest_rate_swap.py
+++ b/pricingengine/instruments/interest_rate_swap.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Type, cast
 
+from pandas import DataFrame, merge, option_context
 from QuantLib import (
     Annual,
     Continuous,
@@ -15,7 +16,6 @@ from QuantLib import (
     YieldTermStructureHandle,
     ZeroSpreadedTermStructure,
 )
-from pandas import DataFrame, merge, option_context
 
 from pricingengine.cashflows.swap_leg import FixedLeg, FloatingLeg, SwapLeg
 from pricingengine.instruments._instrument import Instrument

--- a/pricingengine/instruments/swaption.py
+++ b/pricingengine/instruments/swaption.py
@@ -8,14 +8,13 @@ from QuantLib import (
     BermudanExercise,
     BlackSwaptionEngine,
     Date,
+    DiscountingSwapEngine,
     EuropeanExercise,
     Index,
     Settlement,
     VanillaSwap,
 )
-from QuantLib import (
-    Swaption as QLSwaption,
-)
+from QuantLib import Swaption as QLSwaption
 
 from pricingengine.instruments._instrument import Instrument
 from pricingengine.instruments.interest_rate_swap import InterestRateSwap
@@ -83,7 +82,7 @@ class Swaption(Instrument):
         strike: Optional[float],
     ) -> VanillaSwap:
         """Build a :class:`VanillaSwap` for payoff evaluation."""
-        base = self.swap._vanilla_swap_ql(forecast_index, discount_nodes)
+        base = self.swap._vanilla_swap_ql()
         k = base.fairRate() if strike is None else float(strike)
 
         if self.swap.fixed_leg is self.swap.paying_leg:
@@ -102,7 +101,8 @@ class Swaption(Instrument):
             self.swap.floating_leg.spread,
             self.swap.floating_leg.day_counter,
         )
-        v.setPricingEngine(self.swap._discount_engine(discount_nodes))
+        engine = DiscountingSwapEngine(discount_nodes.to_handle())
+        v.setPricingEngine(engine)
         return v
 
     def _engine(self, discount_nodes: CurveNodes):

--- a/pricingengine/instruments/swaption.py
+++ b/pricingengine/instruments/swaption.py
@@ -76,10 +76,10 @@ class Swaption(Instrument):
         )
 
     def _vanilla_swap_for_pricing(
-            self,
-            forecast_index: Index,
-            discount_nodes: CurveNodes,
-            strike: Optional[float],
+        self,
+        forecast_index: Index,
+        discount_nodes: CurveNodes,
+        strike: Optional[float],
     ) -> VanillaSwap:
         """Build a :class:`VanillaSwap` for payoff evaluation."""
         base = self.swap._vanilla_swap_ql()
@@ -117,7 +117,7 @@ class Swaption(Instrument):
         raise ValueError("vol_type must be 'black' or 'normal'")
 
     def _swaption(
-            self, forecast_index: Index, discount_nodes: CurveNodes
+        self, forecast_index: Index, discount_nodes: CurveNodes
     ) -> QLSwaption:
         vanilla = self._vanilla_swap_for_pricing(
             forecast_index, discount_nodes, self.strike
@@ -129,7 +129,7 @@ class Swaption(Instrument):
     # ------------------------------------------------------------------
     # analytics
     def mark_to_market(
-            self, forecast_index: Index, discount_nodes: CurveNodes
+        self, forecast_index: Index, discount_nodes: CurveNodes
     ) -> float:
         if self.is_expired():
             return 0.0
@@ -146,15 +146,15 @@ class Swaption(Instrument):
         return v if self.is_long else -v
 
     def implied_volatility(
-            self,
-            target_npv: float,
-            forecast_index: Index,
-            discount_nodes: CurveNodes,
-            *,
-            accuracy: float = 1e-7,
-            max_evaluations: int = 500,
-            min_vol: float = 1e-6,
-            max_vol: float = 5.0,
+        self,
+        target_npv: float,
+        forecast_index: Index,
+        discount_nodes: CurveNodes,
+        *,
+        accuracy: float = 1e-7,
+        max_evaluations: int = 500,
+        min_vol: float = 1e-6,
+        max_vol: float = 5.0,
     ) -> float:
         if self.is_expired():
             return 0.0

--- a/pricingengine/instruments/swaption.py
+++ b/pricingengine/instruments/swaption.py
@@ -76,10 +76,10 @@ class Swaption(Instrument):
         )
 
     def _vanilla_swap_for_pricing(
-        self,
-        forecast_index: Index,
-        discount_nodes: CurveNodes,
-        strike: Optional[float],
+            self,
+            forecast_index: Index,
+            discount_nodes: CurveNodes,
+            strike: Optional[float],
     ) -> VanillaSwap:
         """Build a :class:`VanillaSwap` for payoff evaluation."""
         base = self.swap._vanilla_swap_ql()
@@ -117,7 +117,7 @@ class Swaption(Instrument):
         raise ValueError("vol_type must be 'black' or 'normal'")
 
     def _swaption(
-        self, forecast_index: Index, discount_nodes: CurveNodes
+            self, forecast_index: Index, discount_nodes: CurveNodes
     ) -> QLSwaption:
         vanilla = self._vanilla_swap_for_pricing(
             forecast_index, discount_nodes, self.strike
@@ -129,7 +129,7 @@ class Swaption(Instrument):
     # ------------------------------------------------------------------
     # analytics
     def mark_to_market(
-        self, forecast_index: Index, discount_nodes: CurveNodes
+            self, forecast_index: Index, discount_nodes: CurveNodes
     ) -> float:
         if self.is_expired():
             return 0.0
@@ -146,15 +146,15 @@ class Swaption(Instrument):
         return v if self.is_long else -v
 
     def implied_volatility(
-        self,
-        target_npv: float,
-        forecast_index: Index,
-        discount_nodes: CurveNodes,
-        *,
-        accuracy: float = 1e-7,
-        max_evaluations: int = 500,
-        min_vol: float = 1e-6,
-        max_vol: float = 5.0,
+            self,
+            target_npv: float,
+            forecast_index: Index,
+            discount_nodes: CurveNodes,
+            *,
+            accuracy: float = 1e-7,
+            max_evaluations: int = 500,
+            min_vol: float = 1e-6,
+            max_vol: float = 5.0,
     ) -> float:
         if self.is_expired():
             return 0.0

--- a/pricingengine/termstructures/curve_nodes.py
+++ b/pricingengine/termstructures/curve_nodes.py
@@ -167,12 +167,12 @@ class CurveNodes:
     # convenience alternate constructors
     @classmethod
     def from_zeros(
-            cls,
-            as_of: Date,
-            dates: Sequence[Date],
-            zeros: Sequence[float],
-            day_counter: DayCounter,
-            role: CurveRole = "discounting",
+        cls,
+        as_of: Date,
+        dates: Sequence[Date],
+        zeros: Sequence[float],
+        day_counter: DayCounter,
+        role: CurveRole = "discounting",
     ) -> CurveNodes:
         return cls(
             as_of=as_of,
@@ -185,12 +185,12 @@ class CurveNodes:
 
     @classmethod
     def from_discounts(
-            cls,
-            as_of: Date,
-            dates: Sequence[Date],
-            discounts: Sequence[float],
-            day_counter: DayCounter,
-            role: CurveRole = "discounting",
+        cls,
+        as_of: Date,
+        dates: Sequence[Date],
+        discounts: Sequence[float],
+        day_counter: DayCounter,
+        role: CurveRole = "discounting",
     ) -> CurveNodes:
         return cls(
             as_of=as_of,
@@ -203,12 +203,12 @@ class CurveNodes:
 
     @classmethod
     def from_forwards(
-            cls,
-            as_of: Date,
-            dates: Sequence[Date],
-            forwards: Sequence[float],
-            day_counter: DayCounter,
-            role: CurveRole = "forecasting",
+        cls,
+        as_of: Date,
+        dates: Sequence[Date],
+        forwards: Sequence[float],
+        day_counter: DayCounter,
+        role: CurveRole = "forecasting",
     ) -> CurveNodes:
         """Convenience constructor for forward-rate curves."""
         return cls(
@@ -222,12 +222,12 @@ class CurveNodes:
 
     @classmethod
     def from_flat(
-            cls,
-            as_of: Date,
-            maturity: Date,
-            zero: float,
-            day_counter: DayCounter,
-            role: CurveRole = "discounting",
+        cls,
+        as_of: Date,
+        maturity: Date,
+        zero: float,
+        day_counter: DayCounter,
+        role: CurveRole = "discounting",
     ) -> CurveNodes:
         """Flat zero-rate curve out to ``maturity``."""
         return cls(

--- a/pricingengine/termstructures/curve_nodes.py
+++ b/pricingengine/termstructures/curve_nodes.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 from functools import cached_property
-from math import log, exp
-from typing import Sequence, Literal, Optional
+from math import exp, log
+from typing import Literal, Sequence
 
 from QuantLib import (
     Date,
     DayCounter,
-    YieldTermStructureHandle,
-    ZeroCurve,
     DiscountCurve,
-    ForwardCurve,
     FlatForward,
+    ForwardCurve,
     QuoteHandle,
     SimpleQuote,
+    YieldTermStructureHandle,
+    ZeroCurve,
 )
 
 QuoteKind = Literal["zero", "discount", "forward", "flat"]

--- a/pricingengine/termstructures/curve_nodes.py
+++ b/pricingengine/termstructures/curve_nodes.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from functools import cached_property
-from math import exp, log
-from typing import Literal, Sequence
+from math import log, exp
+from typing import Sequence, Literal, Optional
 
 from QuantLib import (
     Date,
     DayCounter,
-    DiscountCurve,
-    FlatForward,
-    ForwardCurve,
-    QuoteHandle,
-    SimpleQuote,
     YieldTermStructureHandle,
     ZeroCurve,
+    DiscountCurve,
+    ForwardCurve,
+    FlatForward,
+    QuoteHandle,
+    SimpleQuote,
 )
 
 QuoteKind = Literal["zero", "discount", "forward", "flat"]
@@ -61,7 +61,10 @@ class CurveNodes:
 
     @cached_property
     def yts_handle(self) -> YieldTermStructureHandle:
-        """Build and cache a QuantLib YieldTermStructureHandle for these nodes."""
+        """
+        Build once and cache a QuantLib YieldTermStructureHandle for these nodes.
+        Subsequent accesses reuse the same handle. (No relinking here.)
+        """
         if self.quote_kind == "zero":
             if len(self.quotes) == 1:
                 yts = FlatForward(

--- a/pricingengine/termstructures/curve_nodes.py
+++ b/pricingengine/termstructures/curve_nodes.py
@@ -167,12 +167,12 @@ class CurveNodes:
     # convenience alternate constructors
     @classmethod
     def from_zeros(
-        cls,
-        as_of: Date,
-        dates: Sequence[Date],
-        zeros: Sequence[float],
-        day_counter: DayCounter,
-        role: CurveRole = "discounting",
+            cls,
+            as_of: Date,
+            dates: Sequence[Date],
+            zeros: Sequence[float],
+            day_counter: DayCounter,
+            role: CurveRole = "discounting",
     ) -> CurveNodes:
         return cls(
             as_of=as_of,
@@ -185,12 +185,12 @@ class CurveNodes:
 
     @classmethod
     def from_discounts(
-        cls,
-        as_of: Date,
-        dates: Sequence[Date],
-        discounts: Sequence[float],
-        day_counter: DayCounter,
-        role: CurveRole = "discounting",
+            cls,
+            as_of: Date,
+            dates: Sequence[Date],
+            discounts: Sequence[float],
+            day_counter: DayCounter,
+            role: CurveRole = "discounting",
     ) -> CurveNodes:
         return cls(
             as_of=as_of,
@@ -203,12 +203,12 @@ class CurveNodes:
 
     @classmethod
     def from_forwards(
-        cls,
-        as_of: Date,
-        dates: Sequence[Date],
-        forwards: Sequence[float],
-        day_counter: DayCounter,
-        role: CurveRole = "forecasting",
+            cls,
+            as_of: Date,
+            dates: Sequence[Date],
+            forwards: Sequence[float],
+            day_counter: DayCounter,
+            role: CurveRole = "forecasting",
     ) -> CurveNodes:
         """Convenience constructor for forward-rate curves."""
         return cls(
@@ -222,12 +222,12 @@ class CurveNodes:
 
     @classmethod
     def from_flat(
-        cls,
-        as_of: Date,
-        maturity: Date,
-        zero: float,
-        day_counter: DayCounter,
-        role: CurveRole = "discounting",
+            cls,
+            as_of: Date,
+            maturity: Date,
+            zero: float,
+            day_counter: DayCounter,
+            role: CurveRole = "discounting",
     ) -> CurveNodes:
         """Flat zero-rate curve out to ``maturity``."""
         return cls(


### PR DESCRIPTION
## Summary
- cache schedule generation and future cashflows in swap legs
- rewrite floating leg to require explicit Ibor index
- refactor interest rate swap to work with bound discount curve handles and provide risk metrics

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9c9f67efc832f809451813d8af21f