### PR TITLE
Refactor swaption to use curve handles

### DIFF
--- a/pricingengine/instruments/swaption.py
+++ b/pricingengine/instruments/swaption.py
@@ -8,9 +8,9 @@ from QuantLib import (
     BermudanExercise,
     BlackSwaptionEngine,
     Date,
-    DiscountingSwapEngine,
     EuropeanExercise,
-    Index,
+    QuoteHandle,
+    SimpleQuote,
     Settlement,
     VanillaSwap,
 )
@@ -18,7 +18,6 @@ from QuantLib import Swaption as QLSwaption
 
 from pricingengine.instruments._instrument import Instrument
 from pricingengine.instruments.interest_rate_swap import InterestRateSwap
-from pricingengine.termstructures.curve_nodes import CurveNodes
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -77,8 +76,6 @@ class Swaption(Instrument):
 
     def _vanilla_swap_for_pricing(
         self,
-        forecast_index: Index,
-        discount_nodes: CurveNodes,
         strike: Optional[float],
     ) -> VanillaSwap:
         """Build a :class:`VanillaSwap` for payoff evaluation."""
@@ -97,59 +94,51 @@ class Swaption(Instrument):
             k,
             self.swap.fixed_leg.day_counter,
             self.swap.floating_leg.future_schedule,
-            forecast_index,
+            self.swap.floating_leg.index,
             self.swap.floating_leg.spread,
             self.swap.floating_leg.day_counter,
         )
-        engine = DiscountingSwapEngine(discount_nodes.to_handle())
-        v.setPricingEngine(engine)
+        v.setPricingEngine(self.swap.discount_engine)
         return v
 
-    def _engine(self, discount_nodes: CurveNodes):
+    def _engine(self):
         dc = self.swap.fixed_leg.day_counter
-        handle = discount_nodes.to_handle()
+        handle = self.swap.discount_curve
         vt = self.volatility
         t = self.vol_type.lower()
+        vol = QuoteHandle(SimpleQuote(float(vt)))
         if t == "black":
-            return BlackSwaptionEngine(handle, float(vt), dc)
+            return BlackSwaptionEngine(handle, vol, dc)
         if t in ("normal", "bachelier"):
-            return BachelierSwaptionEngine(handle, float(vt), dc)
+            return BachelierSwaptionEngine(handle, vol, dc)
         raise ValueError("vol_type must be 'black' or 'normal'")
 
-    def _swaption(
-        self, forecast_index: Index, discount_nodes: CurveNodes
-    ) -> QLSwaption:
-        vanilla = self._vanilla_swap_for_pricing(
-            forecast_index, discount_nodes, self.strike
-        )
+    def _swaption(self) -> QLSwaption:
+        vanilla = self._vanilla_swap_for_pricing(self.strike)
         swpt = QLSwaption(vanilla, self._exercise(), self._settlement())
-        swpt.setPricingEngine(self._engine(discount_nodes))
+        swpt.setPricingEngine(self._engine())
         return swpt
 
     # ------------------------------------------------------------------
     # analytics
-    def mark_to_market(
-        self, forecast_index: Index, discount_nodes: CurveNodes
-    ) -> float:
+    def mark_to_market(self) -> float:
         if self.is_expired():
             return 0.0
-        v = self._swaption(forecast_index, discount_nodes).NPV()
+        v = self._swaption().NPV()
         return v if self.is_long else -v
 
-    def mtm(self, forecast_index: Index, discount_nodes: CurveNodes) -> float:
-        return self.mark_to_market(forecast_index, discount_nodes)
+    def mtm(self) -> float:
+        return self.mark_to_market()
 
-    def vega(self, forecast_index: Index, discount_nodes: CurveNodes) -> float:
+    def vega(self) -> float:
         if self.is_expired():
             return 0.0
-        v = self._swaption(forecast_index, discount_nodes).vega()
+        v = self._swaption().vega()
         return v if self.is_long else -v
 
     def implied_volatility(
         self,
         target_npv: float,
-        forecast_index: Index,
-        discount_nodes: CurveNodes,
         *,
         accuracy: float = 1e-7,
         max_evaluations: int = 500,
@@ -158,14 +147,13 @@ class Swaption(Instrument):
     ) -> float:
         if self.is_expired():
             return 0.0
-        swpt = self._swaption(forecast_index, discount_nodes)
-        engine = self._engine(discount_nodes)
+        swpt = self._swaption()
+        engine = self._engine()
         swpt.setPricingEngine(engine)
-        dc = self.swap.fixed_leg.day_counter
         vol = swpt.impliedVolatility(
             float(target_npv),
-            discount_nodes.to_handle(),
-            dc,
+            self.swap.discount_curve,
+            float(self.volatility),
             accuracy,
             max_evaluations,
             min_vol,
@@ -173,6 +161,6 @@ class Swaption(Instrument):
         )
         return float(vol)
 
-    def atm_strike(self, forecast_index: Index, discount_nodes: CurveNodes) -> float:
-        v = self._vanilla_swap_for_pricing(forecast_index, discount_nodes, None)
+    def atm_strike(self) -> float:
+        v = self._vanilla_swap_for_pricing(None)
         return float(v.fairRate())

--- a/tests/test_swaption_smoke.py
+++ b/tests/test_swaption_smoke.py
@@ -1,0 +1,85 @@
+import QuantLib as ql
+
+from pricingengine.cashflows.swap_leg import FixedLeg, FloatingLeg
+from pricingengine.indices.index_utils import make_forecast_index
+from pricingengine.irs import InterestRateSwap
+from pricingengine.instruments import Swaption
+from pricingengine.termstructures.curve_nodes import CurveNodes
+
+
+def _build_curves():
+    as_of = ql.Date(1, 1, 2020)
+    ql.Settings.instance().evaluationDate = as_of
+    dc = ql.Actual365Fixed()
+    disc = CurveNodes(
+        as_of=as_of,
+        dates=[as_of + ql.Period(50, ql.Years)],
+        quotes=[0.02],
+        day_counter=dc,
+        quote_kind="flat",
+        role="discounting",
+    )
+    fwd = CurveNodes(
+        as_of=as_of,
+        dates=[as_of + ql.Period(50, ql.Years)],
+        quotes=[0.025],
+        day_counter=dc,
+        quote_kind="flat",
+        role="forecasting",
+    )
+    return as_of, dc, disc, fwd
+
+
+def _build_swap(as_of, dc, index, discount_curve, *, issue=None):
+    calendar = ql.TARGET()
+    if issue is None:
+        issue = as_of
+    maturity = calendar.advance(issue, ql.Period(5, ql.Years))
+    notional = 1_000_000
+    fixed_leg = FixedLeg(
+        valuation_date=as_of,
+        nominal=notional,
+        currency="EUR",
+        issue_date=issue,
+        maturity=maturity,
+        tenor=ql.Period(ql.Annual),
+        calendar=calendar,
+        day_counter=dc,
+        rate=0.023,
+    )
+    float_leg = FloatingLeg(
+        valuation_date=as_of,
+        nominal=notional,
+        currency="EUR",
+        issue_date=issue,
+        maturity=maturity,
+        tenor=ql.Period(ql.Semiannual),
+        calendar=calendar,
+        day_counter=dc,
+        index=index,
+        gearing=1.0,
+        spread=0.0,
+    )
+    return InterestRateSwap(
+        paying_leg=fixed_leg, receiving_leg=float_leg, discount_curve=discount_curve
+    )
+
+
+def test_swaption_smoke():
+    as_of, dc, disc_nodes, fwd_nodes = _build_curves()
+    index = make_forecast_index("euribor6m", fwd_nodes)
+    expiry = as_of + ql.Period(1, ql.Years)
+    swap = _build_swap(as_of, dc, index, disc_nodes.yts_handle, issue=expiry)
+    swpt = Swaption(swap=swap, expiries=[expiry])
+
+    mtm = swpt.mark_to_market()
+    assert isinstance(mtm, float)
+
+    vega = swpt.vega()
+    assert isinstance(vega, float)
+
+    atm = swpt.atm_strike()
+    assert isinstance(atm, float)
+
+    iv = swpt.implied_volatility(target_npv=mtm)
+    assert iv > 0


### PR DESCRIPTION
## Summary
- refactor swaption internals to leverage swap's bound curve handles
- replace deleted discount engine helper and remove extra curve arguments
- add smoke test for swaption pricing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e69299dc832faea928ea370ac17a