### PR TITLE
Handle optional QuantLib option engines gracefully

### DIFF
--- a/pricingengine/instruments/equity_option.py
+++ b/pricingengine/instruments/equity_option.py
@@ -7,9 +7,7 @@ from QuantLib import (
     TARGET,
     Actual365Fixed,
     AnalyticEuropeanEngine,
-    BaroneAdesiWhaleyEngine,
     BinomialVanillaEngine,
-    BjerksundStenslandEngine,
     BlackConstantVol,
     BlackScholesMertonProcess,
     BlackVolTermStructureHandle,
@@ -26,18 +24,22 @@ from QuantLib import (
     YieldTermStructureHandle,
 )
 
+try:  # pragma: no cover - optional QuantLib engine
+    from QuantLib import BaroneAdesiWhaleyEngine
+except ImportError:  # pragma: no cover - environment dependent
+    BaroneAdesiWhaleyEngine = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional QuantLib engine
+    from QuantLib import BjerksundStenslandEngine
+except ImportError:  # pragma: no cover - environment dependent
+    BjerksundStenslandEngine = None  # type: ignore[assignment]
+
 from pricingengine.instruments._instrument import Instrument
 
 _ENGINE_ALIASES: dict[str, str] = {
     "analytic": "analytic",
     "black": "analytic",
     "analytic_european": "analytic",
-    "barone_adesi_whaley": "barone_adesi_whaley",
-    "barone-adesi-whaley": "barone_adesi_whaley",
-    "baw": "barone_adesi_whaley",
-    "bjerksund_stensland": "bjerksund_stensland",
-    "bjerksund-stensland": "bjerksund_stensland",
-    "bs": "bjerksund_stensland",
     "fd": "finite_difference",
     "fdm": "finite_difference",
     "finite_difference": "finite_difference",
@@ -45,6 +47,24 @@ _ENGINE_ALIASES: dict[str, str] = {
     "binomial": "binomial",
     "tree": "binomial",
 }
+
+if BjerksundStenslandEngine is not None:
+    _ENGINE_ALIASES.update(
+        {
+            "bjerksund_stensland": "bjerksund_stensland",
+            "bjerksund-stensland": "bjerksund_stensland",
+            "bs": "bjerksund_stensland",
+        }
+    )
+
+if BaroneAdesiWhaleyEngine is not None:
+    _ENGINE_ALIASES.update(
+        {
+            "barone_adesi_whaley": "barone_adesi_whaley",
+            "barone-adesi-whaley": "barone_adesi_whaley",
+            "baw": "barone_adesi_whaley",
+        }
+    )
 
 _BINOMIAL_TREE_ALIASES: dict[str, str] = {
     "jr": "JR",
@@ -252,8 +272,12 @@ class EquityOption(Instrument):
         if resolved == "analytic":
             return AnalyticEuropeanEngine(process)
         if resolved == "barone_adesi_whaley":
+            if BaroneAdesiWhaleyEngine is None:  # pragma: no cover - defensive
+                raise ValueError("Barone-Adesi-Whaley engine is unavailable in this QuantLib build.")
             return BaroneAdesiWhaleyEngine(process)
         if resolved == "bjerksund_stensland":
+            if BjerksundStenslandEngine is None:  # pragma: no cover - defensive
+                raise ValueError("Bjerksund-Stensland engine is unavailable in this QuantLib build.")
             return BjerksundStenslandEngine(process)
         if resolved == "finite_difference":
             return FdBlackScholesVanillaEngine(process, self.time_steps, self.grid_points)


### PR DESCRIPTION
## Summary
- load Barone-Adesi-Whaley and Bjerksund-Stensland option engines lazily so the module imports even when they are absent
- register engine aliases only when the underlying QuantLib engines are available
- raise clear errors if an unavailable engine is requested

## Testing
- `poetry run ruff format pricingengine/instruments/equity_option.py`
- `poetry run ruff check`
- `poetry run pytest tests/instruments`


------
https://chatgpt.com/codex/tasks/task_e_68cb2b0a2e74832fa66eae12a079de0f