### PR TITLE
Remove pytest bootstrap helper and guard optional QuantLib engines

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,0 @@
-import sys
-from pathlib import Path
-
-# Ensure the project root is on sys.path when tests are executed
-# via the `pytest` entry script.
-ROOT = Path(__file__).resolve().parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))

--- a/pricingengine/instruments/equity_option.py
+++ b/pricingengine/instruments/equity_option.py
@@ -7,15 +7,11 @@ from QuantLib import (
     TARGET,
     Actual365Fixed,
     AnalyticEuropeanEngine,
-    BaroneAdesiWhaleyEngine,
-    BinomialVanillaEngine,
-    BjerksundStenslandEngine,
     BlackConstantVol,
     BlackScholesMertonProcess,
     BlackVolTermStructureHandle,
     Date,
     EuropeanExercise,
-    FdBlackScholesVanillaEngine,
     FlatForward,
     Option,
     PlainVanillaPayoff,
@@ -27,6 +23,26 @@ from QuantLib import (
 )
 
 from pricingengine.instruments._instrument import Instrument
+
+try:  # Optional engines depending on QuantLib build
+    from QuantLib import BaroneAdesiWhaleyEngine
+except ImportError:  # pragma: no cover - optional dependency
+    BaroneAdesiWhaleyEngine = None  # type: ignore[assignment]
+
+try:
+    from QuantLib import BinomialVanillaEngine
+except ImportError:  # pragma: no cover - optional dependency
+    BinomialVanillaEngine = None  # type: ignore[assignment]
+
+try:
+    from QuantLib import BjerksundStenslandEngine
+except ImportError:  # pragma: no cover - optional dependency
+    BjerksundStenslandEngine = None  # type: ignore[assignment]
+
+try:
+    from QuantLib import FdBlackScholesVanillaEngine
+except ImportError:  # pragma: no cover - optional dependency
+    FdBlackScholesVanillaEngine = None  # type: ignore[assignment]
 
 _ENGINE_ALIASES: dict[str, str] = {
     "analytic": "analytic",
@@ -252,12 +268,24 @@ class EquityOption(Instrument):
         if resolved == "analytic":
             return AnalyticEuropeanEngine(process)
         if resolved == "barone_adesi_whaley":
+            if BaroneAdesiWhaleyEngine is None:
+                msg = "Barone-Adesi-Whaley engine is unavailable in this QuantLib build"
+                raise RuntimeError(msg)
             return BaroneAdesiWhaleyEngine(process)
         if resolved == "bjerksund_stensland":
+            if BjerksundStenslandEngine is None:
+                msg = "Bjerksund-Stensland engine is unavailable in this QuantLib build"
+                raise RuntimeError(msg)
             return BjerksundStenslandEngine(process)
         if resolved == "finite_difference":
+            if FdBlackScholesVanillaEngine is None:
+                msg = "Finite-difference engine is unavailable in this QuantLib build"
+                raise RuntimeError(msg)
             return FdBlackScholesVanillaEngine(process, self.time_steps, self.grid_points)
         if resolved == "binomial":
+            if BinomialVanillaEngine is None:
+                msg = "Binomial engine is unavailable in this QuantLib build"
+                raise RuntimeError(msg)
             return BinomialVanillaEngine(process, self.binomial_tree, self.time_steps)
         raise ValueError(f"Unsupported engine '{engine}'.")  # pragma: no cover - defensive
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,8 @@ build-backend = "poetry.core.masonry.api"
 dev = [
     "ruff==0.13.0"
 ]
+
+[tool.pytest.ini_options]
+pythonpath = [
+    "."
+]

--- a/tests/instruments/test_fx_forward.py
+++ b/tests/instruments/test_fx_forward.py
@@ -3,154 +3,536 @@ from __future__ import annotations
 import math
 
 import pytest
-import QuantLib as ql
+from QuantLib import (
+    Actual365Fixed,
+    Annual,
+    Continuous,
+    Date,
+    Days,
+    FlatForward,
+    January,
+    July,
+    Months,
+    Period,
+    QuoteHandle,
+    RelinkableQuoteHandle,
+    RelinkableYieldTermStructureHandle,
+    SavedSettings,
+    Settings,
+    SimpleQuote,
+    YieldTermStructureHandle,
+    ZeroSpreadedTermStructure,
+)
 
 from pricingengine.instruments.fx_forward import FXForward
+from pricingengine.termstructures.curve_nodes import CurveNodes
 
 
-def _setup_settings(as_of: ql.Date) -> None:
-    ql.Settings.instance().evaluationDate = as_of
-
-
-def _flat_curve(rate: float) -> ql.RelinkableYieldTermStructureHandle:
-    today = ql.Settings.instance().evaluationDate
-    dc = ql.Actual365Fixed()
-    handle = ql.RelinkableYieldTermStructureHandle()
-    handle.linkTo(ql.FlatForward(today, rate, dc))
+def _flat_curve(rate: float, as_of: Date) -> RelinkableYieldTermStructureHandle:
+    handle = RelinkableYieldTermStructureHandle()
+    handle.linkTo(FlatForward(as_of, rate, Actual365Fixed()))
     return handle
 
 
 @pytest.fixture
-def fx_forward() -> FXForward:
-    today = ql.Date(15, ql.January, 2024)
-    _setup_settings(today)
-    maturity = ql.Date(15, ql.July, 2024)
+def valuation_date() -> Date:
+    return Date(15, January, 2024)
 
-    spot = ql.RelinkableQuoteHandle(ql.SimpleQuote(1.10))
-    forward = ql.RelinkableQuoteHandle(ql.SimpleQuote(1.11))
-    dom_curve = _flat_curve(0.025)
-    for_curve = _flat_curve(0.01)
 
+@pytest.fixture(autouse=True)
+def _apply_saved_settings(valuation_date: Date):
+    with SavedSettings():
+        Settings.instance().evaluationDate = valuation_date
+        yield
+
+
+@pytest.fixture
+def maturity() -> Date:
+    return Date(15, July, 2024)
+
+
+@pytest.fixture
+def notional() -> float:
+    return 1_000_000.0
+
+
+@pytest.fixture
+def spot_handle() -> RelinkableQuoteHandle:
+    return RelinkableQuoteHandle(SimpleQuote(1.10))
+
+
+@pytest.fixture
+def forward_handle() -> RelinkableQuoteHandle:
+    return RelinkableQuoteHandle(SimpleQuote(1.11))
+
+
+@pytest.fixture
+def domestic_curve(valuation_date: Date) -> RelinkableYieldTermStructureHandle:
+    return _flat_curve(0.025, valuation_date)
+
+
+@pytest.fixture
+def foreign_curve(valuation_date: Date) -> RelinkableYieldTermStructureHandle:
+    return _flat_curve(0.01, valuation_date)
+
+
+@pytest.fixture
+def fx_forward_long(
+    maturity: Date,
+    notional: float,
+    forward_handle: RelinkableQuoteHandle,
+    spot_handle: RelinkableQuoteHandle,
+    domestic_curve: RelinkableYieldTermStructureHandle,
+    foreign_curve: RelinkableYieldTermStructureHandle,
+) -> FXForward:
     return FXForward(
         maturity=maturity,
-        notional=1_000_000.0,
-        forward_quote=forward,
-        spot_quote=spot,
-        domestic_curve=dom_curve,
-        foreign_curve=for_curve,
+        notional=notional,
+        forward_quote=forward_handle,
+        spot_quote=spot_handle,
+        domestic_curve=domestic_curve,
+        foreign_curve=foreign_curve,
         is_long_foreign=True,
     )
 
 
-def test_mark_to_market_matches_interest_rate_parity(fx_forward: FXForward) -> None:
-    maturity = fx_forward.maturity
-    dom_curve = fx_forward.domestic_curve
-    for_curve = fx_forward.foreign_curve
-    spot = fx_forward.spot_quote
-    fwd = fx_forward.forward_quote
-
-    df_dom = dom_curve.discount(maturity)
-    df_for = for_curve.discount(maturity)
-    fair_forward = spot.value() * df_for / df_dom
-    expected = fx_forward.notional * (fair_forward - fwd.value()) * df_dom
-
-    assert math.isclose(fx_forward.mark_to_market(), expected, rel_tol=1e-12)
-    assert math.isclose(fx_forward.par_forward(), fair_forward, rel_tol=1e-12)
-
-
-def test_handles_relink_update_value(fx_forward: FXForward) -> None:
-    base = fx_forward.mark_to_market()
-
-    fx_forward.spot_quote.linkTo(ql.SimpleQuote(1.12))
-    bumped_spot_value = fx_forward.mark_to_market()
-    assert not math.isclose(base, bumped_spot_value)
-
-    fx_forward.spot_quote.linkTo(ql.SimpleQuote(1.10))
-
-    dom_curve = fx_forward.domestic_curve
-    link = ql.FlatForward(fx_forward.valuation_date, 0.03, ql.Actual365Fixed())
-    dom_curve.linkTo(link)
-    bumped_curve_value = fx_forward.mark_to_market()
-    assert not math.isclose(base, bumped_curve_value)
-
-
-def test_is_expired_follows_quantlib_settings(fx_forward: FXForward) -> None:
-    assert not fx_forward.is_expired
-    assert fx_forward.mark_to_market() != 0.0
-
-    ql.Settings.instance().evaluationDate = ql.Date(16, ql.July, 2024)
-    assert fx_forward.is_expired
-    assert fx_forward.mark_to_market() == 0.0
-
-
-def test_greeks_and_exposures(fx_forward: FXForward) -> None:
-    fx = fx_forward
-    df_dom = fx.domestic_discount_factor()
-    df_for = fx.foreign_discount_factor()
-
-    expected_delta = fx.notional * df_for
-    assert math.isclose(fx.spot_delta(), expected_delta, rel_tol=1e-12)
-
-    expected_strike_delta = -fx.notional * df_dom
-    assert math.isclose(fx.strike_delta(), expected_strike_delta, rel_tol=1e-12)
-
-    # Domestic IR01 via finite-differencing
-    spread = ql.QuoteHandle(ql.SimpleQuote(1e-4))
-    dom_link = fx.domestic_curve.currentLink()
-    bumped_dom = ql.ZeroSpreadedTermStructure(
-        fx.domestic_curve,
-        spread,
-        ql.Continuous,
-        ql.Annual,
-        dom_link.dayCounter(),
+@pytest.fixture
+def fx_forward_short(
+    maturity: Date,
+    notional: float,
+    forward_handle: RelinkableQuoteHandle,
+    spot_handle: RelinkableQuoteHandle,
+    domestic_curve: RelinkableYieldTermStructureHandle,
+    foreign_curve: RelinkableYieldTermStructureHandle,
+) -> FXForward:
+    return FXForward(
+        maturity=maturity,
+        notional=notional,
+        forward_quote=forward_handle,
+        spot_quote=spot_handle,
+        domestic_curve=domestic_curve,
+        foreign_curve=foreign_curve,
+        is_long_foreign=False,
     )
-    df_dom_bumped = bumped_dom.discount(fx.maturity)
-    fair_forward_bumped = fx.spot * fx.foreign_discount_factor() / df_dom_bumped
-    pv_bumped = fx.notional * (fair_forward_bumped - fx.forward_rate) * df_dom_bumped
-    ir01_expected = (pv_bumped - fx.mark_to_market()) / 1.0
-    assert math.isclose(fx.ir01_domestic(), ir01_expected, rel_tol=1e-10)
 
-    for_link = fx.foreign_curve.currentLink()
-    bumped_for = ql.ZeroSpreadedTermStructure(
-        fx.foreign_curve,
-        spread,
-        ql.Continuous,
-        ql.Annual,
-        for_link.dayCounter(),
+
+@pytest.fixture
+def domestic_nodes(valuation_date: Date, maturity: Date) -> CurveNodes:
+    dates = (
+        valuation_date + Period(3, Months),
+        valuation_date + Period(5, Months),
+        maturity,
     )
-    df_for_bumped = bumped_for.discount(fx.maturity)
-    fair_forward_for = fx.spot * df_for_bumped / fx.domestic_discount_factor()
-    pv_bumped_for = fx.notional * (fair_forward_for - fx.forward_rate) * fx.domestic_discount_factor()
-    ir01_for_expected = (pv_bumped_for - fx.mark_to_market()) / 1.0
-    assert math.isclose(fx.ir01_foreign(), ir01_for_expected, rel_tol=1e-10)
-
-    exposure = fx.currency_exposure()
-    assert exposure["foreign"] == pytest.approx(fx.notional)
-    assert exposure["domestic"] == pytest.approx(-fx.notional * fx.forward_rate)
+    zeros = (0.024, 0.0245, 0.025)
+    return CurveNodes.from_zeros(
+        as_of=valuation_date,
+        dates=dates,
+        zeros=zeros,
+        day_counter=Actual365Fixed(),
+    )
 
 
-def test_cashflow_table_shape(fx_forward: FXForward) -> None:
-    table = fx_forward.cashflow_table()
-    assert list(table.columns) == [
-        "ForeignFlow",
-        "DomesticFlow",
-        "DF(domestic)",
-        "DF(foreign)",
-        "Forward(market)",
-        "Forward(strike)",
-        "PV",
-    ]
-    assert table.index[0] == fx_forward.maturity.ISO()
+@pytest.fixture
+def foreign_nodes(valuation_date: Date, maturity: Date) -> CurveNodes:
+    dates = (
+        valuation_date + Period(3, Months),
+        valuation_date + Period(5, Months),
+        maturity,
+    )
+    zeros = (0.009, 0.0095, 0.01)
+    return CurveNodes.from_zeros(
+        as_of=valuation_date,
+        dates=dates,
+        zeros=zeros,
+        day_counter=Actual365Fixed(),
+    )
 
 
-def test_scenario_helpers_return_new_instances(fx_forward: FXForward) -> None:
-    new = fx_forward.with_spot(1.05)
-    assert new.spot != fx_forward.spot
-    assert new.forward_rate == fx_forward.forward_rate
+# =======================
+# A. Construction & validation
+# =======================
 
-    new_forward = fx_forward.with_forward(1.2)
-    assert new_forward.forward_rate != fx_forward.forward_rate
 
-    bigger = fx_forward.with_notional(2_000_000.0)
-    assert bigger.notional == 2_000_000.0
-    assert bigger.spot == fx_forward.spot
+class TestA_ConstructionAndValidation:
+    def test_requires_non_zero_notional(
+        self,
+        maturity: Date,
+        forward_handle: RelinkableQuoteHandle,
+        spot_handle: RelinkableQuoteHandle,
+        domestic_curve: RelinkableYieldTermStructureHandle,
+        foreign_curve: RelinkableYieldTermStructureHandle,
+    ) -> None:
+        with pytest.raises(ValueError, match="notional must be non-zero"):
+            FXForward(
+                maturity=maturity,
+                notional=0.0,
+                forward_quote=forward_handle,
+                spot_quote=spot_handle,
+                domestic_curve=domestic_curve,
+                foreign_curve=foreign_curve,
+            )
+
+    def test_invalid_settlement_flag_rejected(
+        self,
+        maturity: Date,
+        notional: float,
+        forward_handle: RelinkableQuoteHandle,
+        spot_handle: RelinkableQuoteHandle,
+        domestic_curve: RelinkableYieldTermStructureHandle,
+        foreign_curve: RelinkableYieldTermStructureHandle,
+    ) -> None:
+        with pytest.raises(ValueError, match="settlement must be"):
+            FXForward(
+                maturity=maturity,
+                notional=notional,
+                forward_quote=forward_handle,
+                spot_quote=spot_handle,
+                domestic_curve=domestic_curve,
+                foreign_curve=foreign_curve,
+                settlement="delivery",
+            )
+
+    def test_requires_linked_curves(
+        self,
+        maturity: Date,
+        notional: float,
+        forward_handle: RelinkableQuoteHandle,
+        spot_handle: RelinkableQuoteHandle,
+        domestic_curve: RelinkableYieldTermStructureHandle,
+    ) -> None:
+        unlinked = RelinkableYieldTermStructureHandle()
+        with pytest.raises(ValueError, match="domestic_curve must be linked"):
+            FXForward(
+                maturity=maturity,
+                notional=notional,
+                forward_quote=forward_handle,
+                spot_quote=spot_handle,
+                domestic_curve=unlinked,
+                foreign_curve=domestic_curve,
+            )
+
+    def test_numeric_inputs_wrapped_into_handles(
+        self,
+        maturity: Date,
+        notional: float,
+        domestic_nodes: CurveNodes,
+        foreign_nodes: CurveNodes,
+    ) -> None:
+        fx = FXForward(
+            maturity=maturity,
+            notional=notional,
+            forward_quote=1.125,
+            spot_quote=1.10,
+            domestic_curve=domestic_nodes,
+            foreign_curve=foreign_nodes,
+        )
+        assert isinstance(fx.forward_quote, QuoteHandle)
+        assert isinstance(fx.spot_quote, QuoteHandle)
+        assert isinstance(fx.domestic_curve, YieldTermStructureHandle)
+        assert isinstance(fx.foreign_curve, YieldTermStructureHandle)
+
+    def test_from_nodes_matches_handle_constructor(
+        self,
+        maturity: Date,
+        notional: float,
+        domestic_nodes: CurveNodes,
+        foreign_nodes: CurveNodes,
+    ) -> None:
+        fx_from_nodes = FXForward.from_nodes(
+            maturity=maturity,
+            notional=notional,
+            forward_rate=1.11,
+            spot=1.10,
+            domestic_nodes=domestic_nodes,
+            foreign_nodes=foreign_nodes,
+        )
+
+        fx_direct = FXForward(
+            maturity=maturity,
+            notional=notional,
+            forward_quote=1.11,
+            spot_quote=1.10,
+            domestic_curve=domestic_nodes.to_handle(),
+            foreign_curve=foreign_nodes.to_handle(),
+        )
+
+        assert math.isclose(
+            fx_from_nodes.mark_to_market(),
+            fx_direct.mark_to_market(),
+            rel_tol=1e-12,
+        )
+
+
+# =======================
+# B. Lifecycle & properties
+# =======================
+
+
+class TestB_LifecycleAndProperties:
+    def test_valuation_date_tracks_settings(self, fx_forward_long: FXForward, valuation_date: Date) -> None:
+        future_date = valuation_date + Period(10, Days)
+        with SavedSettings():
+            Settings.instance().evaluationDate = future_date
+            fx = fx_forward_long.with_forward(fx_forward_long.forward_rate)
+            assert fx.valuation_date == future_date
+
+    def test_is_expired_flag(self, fx_forward_long: FXForward, maturity: Date) -> None:
+        assert not fx_forward_long.is_expired
+        with SavedSettings():
+            Settings.instance().evaluationDate = maturity - Period(1, Days)
+            pre_maturity = FXForward(
+                maturity=maturity,
+                notional=fx_forward_long.notional,
+                forward_quote=fx_forward_long.forward_quote,
+                spot_quote=fx_forward_long.spot_quote,
+                domestic_curve=fx_forward_long.domestic_curve,
+                foreign_curve=fx_forward_long.foreign_curve,
+            )
+            assert not pre_maturity.is_expired
+
+            Settings.instance().evaluationDate = maturity
+            on_maturity = FXForward(
+                maturity=maturity,
+                notional=fx_forward_long.notional,
+                forward_quote=fx_forward_long.forward_quote,
+                spot_quote=fx_forward_long.spot_quote,
+                domestic_curve=fx_forward_long.domestic_curve,
+                foreign_curve=fx_forward_long.foreign_curve,
+            )
+            assert on_maturity.is_expired
+
+            Settings.instance().evaluationDate = maturity + Period(1, Days)
+            assert FXForward(
+                maturity=maturity,
+                notional=fx_forward_long.notional,
+                forward_quote=fx_forward_long.forward_quote,
+                spot_quote=fx_forward_long.spot_quote,
+                domestic_curve=fx_forward_long.domestic_curve,
+                foreign_curve=fx_forward_long.foreign_curve,
+            ).is_expired
+
+    def test_direction_flag_controls_sign(self, fx_forward_long: FXForward, fx_forward_short: FXForward) -> None:
+        pv_long = fx_forward_long.mark_to_market()
+        pv_short = fx_forward_short.mark_to_market()
+        assert math.isclose(pv_long, -pv_short, rel_tol=1e-12)
+
+        exposure_long = fx_forward_long.currency_exposure()
+        exposure_short = fx_forward_short.currency_exposure()
+        assert exposure_long["foreign"] == -exposure_short["foreign"]
+        assert exposure_long["domestic"] == -exposure_short["domestic"]
+
+    def test_forward_points_consistency(self, fx_forward_long: FXForward) -> None:
+        forward_points = fx_forward_long.forward_points()
+        assert math.isclose(
+            forward_points,
+            fx_forward_long.par_forward() - fx_forward_long.spot,
+            rel_tol=1e-12,
+        )
+
+    def test_currency_exposure_matches_notional(self, fx_forward_long: FXForward) -> None:
+        exposure = fx_forward_long.currency_exposure()
+        assert exposure["foreign"] == pytest.approx(fx_forward_long.notional)
+        assert exposure["domestic"] == pytest.approx(-fx_forward_long.notional * fx_forward_long.forward_rate)
+
+
+# =======================
+# C. Mark-to-market & pricing dynamics
+# =======================
+
+
+class TestC_MarkToMarketAndPricing:
+    def test_mark_to_market_matches_interest_rate_parity(self, fx_forward_long: FXForward) -> None:
+        fx = fx_forward_long
+        df_dom = fx.domestic_discount_factor()
+        df_for = fx.foreign_discount_factor()
+        fair_forward = fx.spot * df_for / df_dom
+        expected = fx.direction * fx.notional * (fair_forward - fx.forward_rate) * df_dom
+        assert math.isclose(fx.mark_to_market(), expected, rel_tol=1e-12)
+        assert math.isclose(fx.par_forward(), fair_forward, rel_tol=1e-12)
+
+    def test_mtm_zero_when_forward_at_par(self, fx_forward_long: FXForward) -> None:
+        par_rate = fx_forward_long.par_forward()
+        par_forward = fx_forward_long.with_forward(par_rate)
+        assert math.isclose(par_forward.mark_to_market(), 0.0, abs_tol=1e-12)
+
+    def test_mtm_zero_when_expired(self, fx_forward_long: FXForward, maturity: Date) -> None:
+        with SavedSettings():
+            Settings.instance().evaluationDate = maturity + Period(1, Days)
+            assert (
+                FXForward(
+                    maturity=maturity,
+                    notional=fx_forward_long.notional,
+                    forward_quote=fx_forward_long.forward_quote,
+                    spot_quote=fx_forward_long.spot_quote,
+                    domestic_curve=fx_forward_long.domestic_curve,
+                    foreign_curve=fx_forward_long.foreign_curve,
+                ).mark_to_market()
+                == 0.0
+            )
+
+    def test_relinking_handles_updates_value(self, fx_forward_long: FXForward) -> None:
+        base = fx_forward_long.mark_to_market()
+
+        fx_forward_long.spot_quote.linkTo(SimpleQuote(fx_forward_long.spot + 0.01))
+        bumped_spot = fx_forward_long.mark_to_market()
+        assert not math.isclose(base, bumped_spot)
+
+        fx_forward_long.spot_quote.linkTo(SimpleQuote(fx_forward_long.spot))
+        new_curve = FlatForward(fx_forward_long.valuation_date, 0.03, Actual365Fixed())
+        fx_forward_long.domestic_curve.linkTo(new_curve)
+        bumped_curve = fx_forward_long.mark_to_market()
+        assert not math.isclose(base, bumped_curve)
+
+
+# =======================
+# D. Sensitivities & greeks
+# =======================
+
+
+class TestD_SensitivitiesAndGreeks:
+    def test_spot_and_strike_deltas(self, fx_forward_long: FXForward) -> None:
+        df_dom = fx_forward_long.domestic_discount_factor()
+        df_for = fx_forward_long.foreign_discount_factor()
+        assert math.isclose(
+            fx_forward_long.spot_delta(),
+            fx_forward_long.direction * fx_forward_long.notional * df_for,
+            rel_tol=1e-12,
+        )
+        assert math.isclose(
+            fx_forward_long.strike_delta(),
+            -fx_forward_long.direction * fx_forward_long.notional * df_dom,
+            rel_tol=1e-12,
+        )
+
+    def test_deltas_zero_when_expired(self, fx_forward_long: FXForward, maturity: Date) -> None:
+        with SavedSettings():
+            Settings.instance().evaluationDate = maturity + Period(1, Days)
+            expired = FXForward(
+                maturity=maturity,
+                notional=fx_forward_long.notional,
+                forward_quote=fx_forward_long.forward_quote,
+                spot_quote=fx_forward_long.spot_quote,
+                domestic_curve=fx_forward_long.domestic_curve,
+                foreign_curve=fx_forward_long.foreign_curve,
+            )
+            assert expired.spot_delta() == 0.0
+            assert expired.strike_delta() == 0.0
+
+    def test_ir01_domestic_matches_finite_difference(self, fx_forward_long: FXForward) -> None:
+        base = fx_forward_long.mark_to_market()
+
+        spread = QuoteHandle(SimpleQuote(1e-4))
+        dom_link = fx_forward_long.domestic_curve.currentLink()
+        bumped_dom = ZeroSpreadedTermStructure(
+            fx_forward_long.domestic_curve,
+            spread,
+            Continuous,
+            Annual,
+            dom_link.dayCounter(),
+        )
+        bumped_df = bumped_dom.discount(fx_forward_long.maturity)
+        fair_forward_bumped = fx_forward_long.spot * fx_forward_long.foreign_discount_factor() / bumped_df
+        pv_bumped = (
+            fx_forward_long.direction
+            * fx_forward_long.notional
+            * (fair_forward_bumped - fx_forward_long.forward_rate)
+            * bumped_df
+        )
+        expected = (pv_bumped - base) / 1.0
+        assert math.isclose(fx_forward_long.ir01_domestic(), expected, rel_tol=1e-10)
+
+    def test_ir01_foreign_matches_finite_difference(self, fx_forward_long: FXForward) -> None:
+        base = fx_forward_long.mark_to_market()
+
+        spread = QuoteHandle(SimpleQuote(1e-4))
+        for_link = fx_forward_long.foreign_curve.currentLink()
+        bumped_for = ZeroSpreadedTermStructure(
+            fx_forward_long.foreign_curve,
+            spread,
+            Continuous,
+            Annual,
+            for_link.dayCounter(),
+        )
+        df_for_bumped = bumped_for.discount(fx_forward_long.maturity)
+        fair_forward_bumped = fx_forward_long.spot * df_for_bumped / fx_forward_long.domestic_discount_factor()
+        pv_bumped = (
+            fx_forward_long.direction
+            * fx_forward_long.notional
+            * (fair_forward_bumped - fx_forward_long.forward_rate)
+            * fx_forward_long.domestic_discount_factor()
+        )
+        expected = (pv_bumped - base) / 1.0
+        assert math.isclose(fx_forward_long.ir01_foreign(), expected, rel_tol=1e-10)
+
+
+# =======================
+# E. Cash-flows & reporting utilities
+# =======================
+
+
+class TestE_CashflowsAndReporting:
+    def test_cashflow_table_structure(self, fx_forward_long: FXForward) -> None:
+        table = fx_forward_long.cashflow_table()
+        assert list(table.columns) == [
+            "ForeignFlow",
+            "DomesticFlow",
+            "DF(domestic)",
+            "DF(foreign)",
+            "Forward(market)",
+            "Forward(strike)",
+            "PV",
+        ]
+        assert table.index[0] == fx_forward_long.maturity.ISO()
+
+    def test_cash_settlement_flag_has_no_valuation_effect(self, fx_forward_long: FXForward) -> None:
+        cash_settled = FXForward(
+            maturity=fx_forward_long.maturity,
+            notional=fx_forward_long.notional,
+            forward_quote=fx_forward_long.forward_quote,
+            spot_quote=fx_forward_long.spot_quote,
+            domestic_curve=fx_forward_long.domestic_curve,
+            foreign_curve=fx_forward_long.foreign_curve,
+            settlement="cash",
+        )
+        assert math.isclose(
+            cash_settled.mark_to_market(),
+            fx_forward_long.mark_to_market(),
+            rel_tol=1e-12,
+        )
+
+    def test_as_dict_contains_serializable_snapshot(self, fx_forward_long: FXForward) -> None:
+        payload = fx_forward_long.as_dict()
+        assert payload["valuation_date"] == fx_forward_long.valuation_date.ISO()
+        assert payload["maturity"] == fx_forward_long.maturity.ISO()
+        assert payload["notional"] == fx_forward_long.notional
+        assert payload["forward_rate"] == fx_forward_long.forward_rate
+        assert payload["spot"] == fx_forward_long.spot
+        assert payload["is_long_foreign"] is True
+        assert payload["settlement"] == fx_forward_long.settlement
+
+
+# =======================
+# F. Scenario helpers
+# =======================
+
+
+class TestF_ScenarioUtilities:
+    def test_with_spot_returns_new_instance(self, fx_forward_long: FXForward) -> None:
+        bumped = fx_forward_long.with_spot(fx_forward_long.spot + 0.05)
+        assert bumped is not fx_forward_long
+        assert bumped.spot == fx_forward_long.spot + 0.05
+        assert bumped.forward_rate == fx_forward_long.forward_rate
+
+    def test_with_forward_accepts_handle_or_number(self, fx_forward_long: FXForward) -> None:
+        new_forward = fx_forward_long.with_forward(1.15)
+        assert math.isclose(new_forward.forward_rate, 1.15)
+
+        handle = RelinkableQuoteHandle(SimpleQuote(1.20))
+        new_forward_handle = fx_forward_long.with_forward(handle)
+        assert new_forward_handle.forward_quote is handle
+
+    def test_with_notional_scales_currency_exposure(self, fx_forward_long: FXForward) -> None:
+        scaled = fx_forward_long.with_notional(2 * fx_forward_long.notional)
+        exposure = scaled.currency_exposure()
+        assert exposure["foreign"] == pytest.approx(2 * fx_forward_long.notional)
+        assert exposure["domestic"] == pytest.approx(-2 * fx_forward_long.notional * fx_forward_long.forward_rate)


### PR DESCRIPTION
## Summary
- drop the repository-level `conftest.py` bootstrap
- configure pytest to add the project root to `PYTHONPATH` via `pyproject.toml`
- adjust the equity option instrument to tolerate missing optional QuantLib engines and raise informative errors when requested
- switch the equity option implementation and FX forward tests to import explicit QuantLib symbols instead of the `ql` alias

## Testing
- ruff check
- pytest tests/instruments

------
https://chatgpt.com/codex/tasks/task_e_68cb2b7f8c5c832f821b709efa55d3a1