### PR TITLE
Refactor portfolio engine imports and expose public API

### DIFF
--- a/portfolioengine/__init__.py
+++ b/portfolioengine/__init__.py
@@ -1,0 +1,36 @@
+"""Portfolio engine public API."""
+
+from . import computation
+from .computation import compute, compute_instrument, compute_portfolio
+from .factor_utils import get_factors
+from .instrument_registry import get_instrument_class, get_metric_function
+from .portfolio_engine_registry import (
+    get_engine_class,
+    get_engine_metric_function,
+)
+from .positions import (
+    IRS,
+    ClientPosition,
+    EquityOption,
+    FXForward,
+    FXOption,
+    Repo,
+)
+
+__all__ = [
+    "ClientPosition",
+    "EquityOption",
+    "FXForward",
+    "FXOption",
+    "IRS",
+    "Repo",
+    "compute",
+    "compute_instrument",
+    "compute_portfolio",
+    "computation",
+    "get_engine_class",
+    "get_engine_metric_function",
+    "get_factors",
+    "get_instrument_class",
+    "get_metric_function",
+]

--- a/portfolioengine/computation.py
+++ b/portfolioengine/computation.py
@@ -1,18 +1,16 @@
-from typing import Tuple, Any
+from typing import Any, Tuple
 
-from rvs_engine_interface.instrument_registry import (
+from .instrument_registry import (
     get_instrument_class,
     get_metric_function,
 )
-from rvs_engine_interface.portfolio_engine_registry import (
+from .portfolio_engine_registry import (
     get_engine_class,
     get_engine_metric_function,
 )
 
 
-def compute_instrument(
-    metric: str, instr_type: str, factors: dict
-) -> Tuple[Any, dict]:  # previously compute()
+def compute_instrument(metric: str, instr_type: str, factors: dict) -> Tuple[Any, dict]:  # previously compute()
     # Convenience method to simplify api.
     if None in (metric, instr_type, factors):
         raise ValueError("Missing input.")
@@ -41,8 +39,9 @@ def compute(
     if None in (metric, instr_type, factors):
         raise ValueError("Missing input.")
     if instr_type == "Portfolio":
-        return compute_portfolio(
-            metric, metric, factors
-        )  # both taking Metric now from "VaR". May need sub_metric for more granularity here. E.g. instr= Portfolio + metric = VaR + subMetric = position_level/portfolio_level/Attribution/stresstest etc.
+        # Both arguments currently use the metric (e.g. "VaR").
+        # May need sub-metric support for finer granularity in the future,
+        # such as distinguishing position-level, attribution or stress tests.
+        return compute_portfolio(metric, metric, factors)
     else:
         return compute_instrument(metric, instr_type, factors)

--- a/portfolioengine/data_structures/QL_Mapping.py
+++ b/portfolioengine/data_structures/QL_Mapping.py
@@ -1,15 +1,24 @@
-from enum import Enum
 from contextlib import contextmanager
-from QuantLib import Settings, Date as QLDate
-from QuantLib import Actual360, ActualActual, Thirty360
+from enum import Enum
+
 from QuantLib import (
-    IborIndex,
     TARGET,
-    YieldTermStructureHandle,
-    Period,
+    Actual360,
+    ActualActual,
+    EURCurrency,
+    GBPCurrency,
+    IborIndex,
     ModifiedFollowing,
+    NOKCurrency,
+    Period,
+    SEKCurrency,
+    Settings,
+    Thirty360,
+    USDCurrency,
+    YieldTermStructureHandle,
 )
-from QuantLib import NOKCurrency, USDCurrency, EURCurrency, GBPCurrency, SEKCurrency
+from QuantLib import Date as QLDate
+
 from pricingengine.cashflows.swap_leg import (
     AmortizedFixedLeg,
     AmortizedFloatingLeg,

--- a/portfolioengine/data_structures/__init__.py
+++ b/portfolioengine/data_structures/__init__.py
@@ -1,0 +1,25 @@
+"""Helpers for mapping market data to QuantLib friendly structures."""
+
+from .market_data_mapper import CurveData, MarketDataMapper, SurfaceData
+from .QL_Mapping import (
+    QL_ccy_mapper,
+    QL_day_count_mapper,
+    QL_swap_leg_mapper,
+    fx_base_price_invert,
+    fx_direction_alignment,
+    generic_ibor,
+    ql_eval_date,
+)
+
+__all__ = [
+    "CurveData",
+    "MarketDataMapper",
+    "QL_ccy_mapper",
+    "QL_day_count_mapper",
+    "QL_swap_leg_mapper",
+    "SurfaceData",
+    "fx_base_price_invert",
+    "fx_direction_alignment",
+    "generic_ibor",
+    "ql_eval_date",
+]

--- a/portfolioengine/data_structures/market_data_mapper.py
+++ b/portfolioengine/data_structures/market_data_mapper.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass, field
-from typing import Optional, Dict, Tuple, List
+from typing import Dict, List, Optional, Tuple
+
 import numpy as np
 import QuantLib as ql
+
 from pricingengine.termstructures.curve import Curve
 
 
@@ -71,7 +73,9 @@ class SurfaceData:
     vol_grid: Optional[List[List[float]]] = None
 
     def init_surface(self, ref_date: ql.Date, ql_dayCounter: ql.DayCounter):
-        # Init values and ql_marturities from the reference date. note that we can't initialize absolute strikes, as we want "sticky moneyness" not "sticky strikes"
+        # Init values and ql_maturities from the reference date.
+        # We deliberately avoid initializing absolute strikes; the volatility
+        # surface works with "sticky moneyness" rather than "sticky strikes".
         self.ql_dayCounter = ql_dayCounter
         self.ql_ref_date = ref_date
         # Build canonical maturity axis (strictly increasing) and moneyness axis (unique + sorted). Pre-compute indexing
@@ -89,9 +93,7 @@ class SurfaceData:
         grid = [[0.0 for _ in range(I_)] for _ in range(J)]
         N = len(self.seriesNames)
         assert (
-            len(self.maturities) == N
-            and len(self.moneyness) == N
-            and len(self.seriesValues) == N
+            len(self.maturities) == N and len(self.moneyness) == N and len(self.seriesValues) == N
         )  # Check consistency
         for k in range(N):
             d = self.ql_maturities[k]
@@ -103,9 +105,7 @@ class SurfaceData:
 
         # Keep track of which name corresponds to which moneyness+maturity for easy updating for risk (need seriesName)
         self.grid_positions.clear()
-        if self.seriesNames is not None and all(
-            n is not None for n in self.seriesNames
-        ):
+        if self.seriesNames is not None and all(n is not None for n in self.seriesNames):
             names = list(self.seriesNames)
             if len(set(names)) == len(names):
                 for k, name in enumerate(names):
@@ -129,9 +129,7 @@ class SurfaceData:
         ]  # Re-calculate the absolute strikes of surface with the (stressed) spot rate
         # Assure increasing strikes by QL convention
         # Moneyness : AHS data is spot/strike=moneynesss so we sort ascending by mn
-        perm = sorted(
-            range(len(strikes)), key=lambda i: strikes[i]
-        )  # ascending by strike
+        perm = sorted(range(len(strikes)), key=lambda i: strikes[i])  # ascending by strike
         strikes_sorted = [strikes[i] for i in perm]
         grid_sorted = [grid[i] for i in perm]  # reorder rows the same way
 
@@ -159,26 +157,18 @@ class MarketDataMapper:
         tenors: list[str] = None,
         seriesValues: np.ndarray = None,
     ) -> None:  # Can add validation error if not same length of arrays/lists
-        if (
-            seriesNames is None
-        ):  # create dummy array of length of either mat or tenor if no names are given.
+        if seriesNames is None:  # create dummy array of length of either mat or tenor if no names are given.
             tenor_len = len(tenors) if tenors is not None else 0
             maturities_len = len(maturities) if maturities is not None else 0
             seriesNames = np.empty(max(tenor_len, maturities_len))
 
         if seriesValues is None:
-            seriesValues = np.empty(
-                len(seriesNames)
-            )  # set to empty array of same length of no values added (default)
+            seriesValues = np.empty(len(seriesNames))  # set to empty array of same length of no values added (default)
         else:
-            seriesValues = np.array(
-                seriesValues
-            )  # Convert to np.array if passed as list
+            seriesValues = np.array(seriesValues)  # Convert to np.array if passed as list
 
         if maturities is None:
-            maturities = np.empty(
-                len(seriesNames)
-            )  # set to empty array of same length of no values added (default)
+            maturities = np.empty(len(seriesNames))  # set to empty array of same length of no values added (default)
         ql_maturities = np.empty(
             len(seriesNames)
         )  # Always set to empty and created with value date and tenors when setting up position
@@ -208,9 +198,7 @@ class MarketDataMapper:
         # Sort arrays by maturities in ascending order before creating CurveData object
         seriesNames = [seriesNames[i] for i in sortedIndices]
         seriesValues = seriesValues[sortedIndices]
-        ql_tenors = [
-            ql_tenors[i] for i in sortedIndices
-        ]  # Keep as list for QuantLib objects
+        ql_tenors = [ql_tenors[i] for i in sortedIndices]  # Keep as list for QuantLib objects
         # maturities = maturities[sortedIndices]
 
         curveData = CurveData(
@@ -243,9 +231,7 @@ class MarketDataMapper:
         if seriesValues is None:
             seriesValues = np.empty(len(seriesNames))
         else:
-            seriesValues = np.array(
-                seriesValues
-            )  # Convert to np.array if passed as list
+            seriesValues = np.array(seriesValues)  # Convert to np.array if passed as list
 
         if maturities is None:
             maturities = np.empty(len(seriesNames))
@@ -258,9 +244,7 @@ class MarketDataMapper:
         ql_tenors = [None] * len(seriesNames)
 
         # Parse tenors if provided
-        if (
-            tenors is not None and tenors[0] is not None
-        ):  # assuming all are None or none are
+        if tenors is not None and tenors[0] is not None:  # assuming all are None or none are
             for i, tenor in enumerate(tenors):
                 # Parse the tenor string
                 if tenor.endswith("D"):
@@ -275,7 +259,8 @@ class MarketDataMapper:
         else:
             ql_tenors = np.empty(len(seriesNames), dtype=object)
 
-        # To do: Put Matrix stuff here (maybe - need value date then as well for converting ql_maturitie. Do we mind it here?)
+        # TODO: Add matrix support once the value date conversion logic is in
+        # place (required for building ql_maturities on demand).
 
         surfaceData = SurfaceData(
             surfaceName=surfaceName,

--- a/portfolioengine/instrument_registry.py
+++ b/portfolioengine/instrument_registry.py
@@ -1,19 +1,11 @@
 from enum import Enum
 
-from rvs_engine_interface.client_positions.Repo import (
-    Repo,
-)
-from rvs_engine_interface.client_positions.equity_option import (
-    EquityOption,
-)
-from rvs_engine_interface.client_positions.fx_forward import (
-    FXForward,
-)
-from rvs_engine_interface.client_positions.fx_option import (
-    FXOption,
-)
-from rvs_engine_interface.client_positions.interest_rate_swap import (
+from .positions import (
     IRS,
+    EquityOption,
+    FXForward,
+    FXOption,
+    Repo,
 )
 
 

--- a/portfolioengine/portfolio_engine_registry.py
+++ b/portfolioengine/portfolio_engine_registry.py
@@ -1,8 +1,6 @@
-from rvs_engine_interface.risk_engine.risk_engine_interface import (
-    InitializeRiskEngine,
-)
-
 from enum import Enum
+
+from .risk_engine.risk_engine_interface import InitializeRiskEngine
 
 
 class EngineMetricFunction(Enum):

--- a/portfolioengine/positions/Repo.py
+++ b/portfolioengine/positions/Repo.py
@@ -1,14 +1,14 @@
 from datetime import date
 
-from rvs_engine_interface.client_positions.QL_Mapping import (
-    QL_day_count_mapper,
-)
-from rvs_engine_interface.client_positions.client_positions import ClientPosition
-from rvs_engine_interface.client_positions.QL_Mapping import ql_eval_date
-
 from QuantLib import (
     Date,
 )
+
+from ..data_structures.QL_Mapping import (
+    QL_day_count_mapper,
+    ql_eval_date,
+)
+from .client_positions import ClientPosition
 
 
 class Repo(ClientPosition):
@@ -37,26 +37,18 @@ class Repo(ClientPosition):
         self.ql_day_count = QL_day_count_mapper[day_count].value
 
         self.valueDate = (
-            date.fromisoformat(value_date)
-            if not isinstance(value_date, date)
-            else value_date
+            date.fromisoformat(value_date) if not isinstance(value_date, date) else value_date
         )  # input dates as e.g. "2024-02-13" and convert in instantiation
-        self.ql_value_date = Date(
-            self.valueDate.day, self.valueDate.month, self.valueDate.year
-        )
+        self.ql_value_date = Date(self.valueDate.day, self.valueDate.month, self.valueDate.year)
 
         self.maturity = (
             date.fromisoformat(maturity) if not isinstance(maturity, date) else maturity
         )  # input dates as e.g. "2024-02-13" and convert in instantiation
         self.cash_flows = None  # initialize and fill with used market data / debug info
         self.issue_date = (
-            date.fromisoformat(issue_date)
-            if not isinstance(issue_date, date)
-            else issue_date
+            date.fromisoformat(issue_date) if not isinstance(issue_date, date) else issue_date
         )  # input dates as e.g. "2024-02-13" and convert in instantiation
-        self.ql_issue_date = Date(
-            self.issue_date.day, self.issue_date.month, self.issue_date.year
-        )
+        self.ql_issue_date = Date(self.issue_date.day, self.issue_date.month, self.issue_date.year)
 
     def valuePosition(
         self,
@@ -68,18 +60,10 @@ class Repo(ClientPosition):
 
     def MTM(self) -> tuple[float, dict, str]:  # "MTM" calc for PCS collateralization
         with ql_eval_date(self.ql_value_date):  # Sets the global evaluation date
-            accrual_fraction = self.ql_day_count.yearFraction(
-                self.ql_issue_date, self.ql_value_date
-            )
-            accrued_interest = (
-                self.initial_cash_amount * self.repo_rate * accrual_fraction
-            )
+            accrual_fraction = self.ql_day_count.yearFraction(self.ql_issue_date, self.ql_value_date)
+            accrued_interest = self.initial_cash_amount * self.repo_rate * accrual_fraction
             cash_value = self.initial_cash_amount + accrued_interest
-            collateral_value = (
-                (self.underlying_dirty_price / 100.0)
-                * self.underlying_nominal
-                * (1 - self.hair_cut)
-            )
+            collateral_value = (self.underlying_dirty_price / 100.0) * self.underlying_nominal * (1 - self.hair_cut)
             mtm = cash_value - collateral_value
             used_risk_factors = {
                 "initial_cash_amount": self.initial_cash_amount,

--- a/portfolioengine/positions/__init__.py
+++ b/portfolioengine/positions/__init__.py
@@ -1,0 +1,17 @@
+"""Portfolio engine position wrappers."""
+
+from .client_positions import ClientPosition
+from .equity_option import EquityOption
+from .fx_forward import FXForward
+from .fx_option import FXOption
+from .interest_rate_swap import IRS
+from .Repo import Repo
+
+__all__ = [
+    "ClientPosition",
+    "EquityOption",
+    "FXForward",
+    "FXOption",
+    "IRS",
+    "Repo",
+]

--- a/portfolioengine/positions/client_positions.py
+++ b/portfolioengine/positions/client_positions.py
@@ -7,7 +7,9 @@ class ClientPosition(ABC):
         pass  # Here could make use of e.g. QuantLib for valuation
 
     def setUpPosition(self) -> None:
-        pass  # Called after applying risk factors to calibrate position. e.g. (re)calculate z-spread for bonds to match dirtyPrice.
+        # Called after applying risk factors to calibrate position
+        # e.g. (re)calculate z-spread for bonds to match dirty price.
+        pass
 
     def incrementValueDate(self, daysToAdd: int) -> None:
         pass

--- a/portfolioengine/positions/equity_option.py
+++ b/portfolioengine/positions/equity_option.py
@@ -5,28 +5,31 @@ from typing import Literal
 
 import numpy as np
 from QuantLib import (
+    Actual360,
+    Actual365Fixed,
+    BlackVolTermStructureHandle,
+    Continuous,
     Date,
     QuoteHandle,
     SimpleQuote,
-    Actual360,
-    Actual365Fixed,
     YieldTermStructureHandle,
-    BlackVolTermStructureHandle,
-    Option as QLOption,
-    Continuous,
 )
+from QuantLib import (
+    Option as QLOption,
+)
+
 # pricingengine instruments
 from pricingengine.instruments.equity_option import (
-    OptionEngineParameters,
-    EuropeanVanillaOption,
     AmericanVanillaOption,
     BermudanVanillaOption,
     EuropeanDigitalOption,
+    EuropeanVanillaOption,
+    OptionEngineParameters,
 )
 
-from rvs_engine_interface.client_positions.QL_Mapping import ql_eval_date
-from rvs_engine_interface.client_positions.client_positions import ClientPosition
-from rvs_engine_interface.client_positions.market_data_mapper import MarketDataMapper
+from ..data_structures.market_data_mapper import MarketDataMapper
+from ..data_structures.QL_Mapping import ql_eval_date
+from .client_positions import ClientPosition
 
 
 class EquityOption(ClientPosition):
@@ -73,14 +76,8 @@ class EquityOption(ClientPosition):
         pos_name: str | None = None,
     ):
         self.posName = pos_name
-        self.valueDate = (
-            date.fromisoformat(value_date)
-            if not isinstance(value_date, date)
-            else value_date
-        )
-        self.ql_value_date = Date(
-            self.valueDate.day, self.valueDate.month, self.valueDate.year
-        )
+        self.valueDate = date.fromisoformat(value_date) if not isinstance(value_date, date) else value_date
+        self.ql_value_date = Date(self.valueDate.day, self.valueDate.month, self.valueDate.year)
 
         self.spot = spot
         self.optionTypeBool = is_call
@@ -93,19 +90,10 @@ class EquityOption(ClientPosition):
 
         # maturity or exercise dates
         self.maturity = (
-            None
-            if maturity is None
-            else (
-                date.fromisoformat(maturity)
-                if not isinstance(maturity, date)
-                else maturity
-            )
+            None if maturity is None else (date.fromisoformat(maturity) if not isinstance(maturity, date) else maturity)
         )
         if exercise_dates:
-            self.exerciseDates = [
-                (date.fromisoformat(d) if not isinstance(d, date) else d)
-                for d in exercise_dates
-            ]
+            self.exerciseDates = [(date.fromisoformat(d) if not isinstance(d, date) else d) for d in exercise_dates]
         else:
             self.exerciseDates = None
 
@@ -113,9 +101,7 @@ class EquityOption(ClientPosition):
 
         # style sanity
         if self.style not in {"european", "american", "bermudan", "digital"}:
-            raise ValueError(
-                "style must be one of {'european','american','bermudan','digital'}"
-            )
+            raise ValueError("style must be one of {'european','american','bermudan','digital'}")
         if self.style != "bermudan" and self.maturity is None:
             raise ValueError("maturity is required unless style='bermudan'")
         if self.style == "bermudan" and not self.exerciseDates:
@@ -141,9 +127,7 @@ class EquityOption(ClientPosition):
         mdm.addSurfaceData(
             surfaceName="EQ_VOL_SURFACE",
             tenors=vol_surface["tenors"],
-            strikes=np.array(
-                vol_surface["strikes"], dtype=float
-            ),  # moneyness = spot/strike
+            strikes=np.array(vol_surface["strikes"], dtype=float),  # moneyness = spot/strike
             seriesValues=np.array(vol_surface["vols"], dtype=float),
         )
 
@@ -175,9 +159,7 @@ class EquityOption(ClientPosition):
             if self.style == "american":
                 return OptionEngineParameters.baw(), "baw"
             if self.style == "bermudan":
-                return OptionEngineParameters.tree(
-                    steps=201, method="lr"
-                ), "tree method:{} steps:{}".format("lr", 201)
+                return OptionEngineParameters.tree(steps=201, method="lr"), "tree method:{} steps:{}".format("lr", 201)
             raise ValueError(f"Unsupported style '{self.style}'")
 
         key = str(ep.get("engine", "")).lower().strip()
@@ -186,9 +168,7 @@ class EquityOption(ClientPosition):
         if key == "fd":
             nt = int(ep.get("nt", 121))
             nx = int(ep.get("nx", 241))
-            return OptionEngineParameters.fd(nt=nt, nx=nx), "fd nt:{} nx:{}".format(
-                nt, nx
-            )
+            return OptionEngineParameters.fd(nt=nt, nx=nx), "fd nt:{} nx:{}".format(nt, nx)
         if key == "baw":
             return OptionEngineParameters.baw(), "baw"
         if key == "bjerksund":
@@ -198,9 +178,9 @@ class EquityOption(ClientPosition):
                 raise ValueError("tree engine requires 'steps' and 'method'")
             steps = int(ep["steps"])
             method = str(ep["method"])
-            return OptionEngineParameters.tree(
-                method=method, steps=steps
-            ), "tree method:{} steps:{}".format(method, steps)
+            return OptionEngineParameters.tree(method=method, steps=steps), "tree method:{} steps:{}".format(
+                method, steps
+            )
 
         raise ValueError(f"Unknown engine '{key}' in engine_params")
 
@@ -228,9 +208,7 @@ class EquityOption(ClientPosition):
 
             # --- choose instrument class by style ---
             self.ql_maturity = (
-                Date(self.maturity.day, self.maturity.month, self.maturity.year)
-                if self.maturity is not None
-                else None
+                Date(self.maturity.day, self.maturity.month, self.maturity.year) if self.maturity is not None else None
             )
 
             if self.style == "european":
@@ -303,25 +281,17 @@ class EquityOption(ClientPosition):
             probe_date = (
                 opt.maturity
                 if hasattr(opt, "maturity") and opt.maturity
-                else (
-                    opt.exercise_dates[-1]
-                    if hasattr(opt, "exercise_dates")
-                    else self.ql_value_date
-                )
+                else (opt.exercise_dates[-1] if hasattr(opt, "exercise_dates") else self.ql_value_date)
             )
             try:
                 self.used_df = float(disc_curve.discount(probe_date))
-                self.used_rf = float(
-                    disc_curve.zeroRate(probe_date, self.day_count, Continuous).rate()
-                )
+                self.used_rf = float(disc_curve.zeroRate(probe_date, self.day_count, Continuous).rate())
             except Exception:
                 self.used_df = None
                 self.used_rf = None
             try:
                 self.used_dq = float(div_curve.discount(probe_date))
-                self.used_rq = float(
-                    div_curve.zeroRate(probe_date, self.day_count, Continuous).rate()
-                )
+                self.used_rq = float(div_curve.zeroRate(probe_date, self.day_count, Continuous).rate())
             except Exception:
                 self.used_dq = None
                 self.used_rq = None
@@ -332,9 +302,7 @@ class EquityOption(ClientPosition):
                 self.used_vol = None
 
             try:
-                self.maturity_yf = disc_curve.dayCounter().yearFraction(
-                    disc_curve.referenceDate(), self.ql_maturity
-                )
+                self.maturity_yf = disc_curve.dayCounter().yearFraction(disc_curve.referenceDate(), self.ql_maturity)
             except Exception:
                 self.maturity_yf = None
 

--- a/portfolioengine/positions/fx_forward.py
+++ b/portfolioengine/positions/fx_forward.py
@@ -4,22 +4,22 @@ from datetime import date
 
 import numpy as np
 from QuantLib import (
+    TARGET,
     Actual360,
     Date,
-    YieldTermStructureHandle,
+    ModifiedFollowing,
     QuoteHandle,
     SimpleQuote,
-    TARGET,
-    ModifiedFollowing,
+    YieldTermStructureHandle,
 )
+
 from pricingengine.instruments.fx_forward import (
     FxForward,
 )
 
-from rvs_engine_interface.client_positions.QL_Mapping import fx_base_price_invert
-from rvs_engine_interface.client_positions.QL_Mapping import ql_eval_date
-from rvs_engine_interface.client_positions.client_positions import ClientPosition
-from rvs_engine_interface.client_positions.market_data_mapper import MarketDataMapper
+from ..data_structures.market_data_mapper import MarketDataMapper
+from ..data_structures.QL_Mapping import fx_base_price_invert, ql_eval_date
+from .client_positions import ClientPosition
 
 
 class FXForward(ClientPosition):
@@ -35,14 +35,8 @@ class FXForward(ClientPosition):
         posName: str = None,
     ):
         self.posName = posName
-        self.valueDate = (
-            date.fromisoformat(value_date)
-            if not isinstance(value_date, date)
-            else value_date
-        )
-        self.ql_value_date = Date(
-            self.valueDate.day, self.valueDate.month, self.valueDate.year
-        )
+        self.valueDate = date.fromisoformat(value_date) if not isinstance(value_date, date) else value_date
+        self.ql_value_date = Date(self.valueDate.day, self.valueDate.month, self.valueDate.year)
 
         self.nominal = nominal
         self.strikePrice = float(strike_price)
@@ -51,9 +45,7 @@ class FXForward(ClientPosition):
         self.baseCCYRate = float(spot_rate["base_ccy_rate"])
         self.priceCCYRate = float(spot_rate["price_ccy_rate"])
 
-        self.maturity = (
-            date.fromisoformat(maturity) if not isinstance(maturity, date) else maturity
-        )
+        self.maturity = date.fromisoformat(maturity) if not isinstance(maturity, date) else maturity
         self.day_count = Actual360()
 
         mdm = MarketDataMapper()
@@ -91,9 +83,7 @@ class FXForward(ClientPosition):
             self.baseFXPointsCurveData.init_curve(self.ql_value_date, self.day_count)
             self.priceFXPointsCurveData.init_curve(self.ql_value_date, self.day_count)
 
-            discount_handle = YieldTermStructureHandle(
-                self.discountCurveData.ql_ZeroCurve()
-            )
+            discount_handle = YieldTermStructureHandle(self.discountCurveData.ql_ZeroCurve())
 
             # Compute spot S (PRICE/BASE), respecting market inversion flags
             if fx_base_price_invert(self.baseCCY):
@@ -130,18 +120,11 @@ class FXForward(ClientPosition):
             points_price_base = implied_f - s  # PRICE terms, same direction as spot
 
             # assemble list[dict] for FxForward (tenor strings + points)
-            tenors = (
-                self.priceFXPointsCurveData.ql_tenors
-            )  # original tenor strings from MarketDataMapper
-            fx_pts_curve = [
-                {"tenor": str(ten), "points": float(pts)}
-                for ten, pts in zip(tenors, points_price_base)
-            ]
+            tenors = self.priceFXPointsCurveData.ql_tenors  # original tenor strings from MarketDataMapper
+            fx_pts_curve = [{"tenor": str(ten), "points": float(pts)} for ten, pts in zip(tenors, points_price_base)]
 
             # Instantiate pricingengine FxForward (it bootstraps the foreign curve via FxSwapRateHelper)
-            ql_maturity = Date(
-                self.maturity.day, self.maturity.month, self.maturity.year
-            )
+            ql_maturity = Date(self.maturity.day, self.maturity.month, self.maturity.year)
             engine = FxForward(
                 nominal=self.nominal if self.nominal >= 0 else -self.nominal,
                 forward_price=self.strikePrice,

--- a/portfolioengine/positions/fx_option.py
+++ b/portfolioengine/positions/fx_option.py
@@ -1,4 +1,5 @@
-# rvs_engine_interface/client_positions/fx_option.py
+# Portfolio engine FX option implementation built on top of the local
+# equity option wrapper.
 
 from __future__ import annotations
 
@@ -7,12 +8,9 @@ from typing import Literal
 
 from QuantLib import Date
 
-from rvs_engine_interface.client_positions.QL_Mapping import ql_eval_date
-from rvs_engine_interface.client_positions.client_positions import ClientPosition
-# Reuse the RVS EquityOption wrapper
-from rvs_engine_interface.client_positions.equity_option import (
-    EquityOption as RVSEquityOption,
-)
+from ..data_structures.QL_Mapping import ql_eval_date
+from .client_positions import ClientPosition
+from .equity_option import EquityOption as PortfolioEquityOption
 
 StyleKey = Literal["european", "american", "bermudan", "digital"]
 EngineKey = Literal["analytic", "fd", "baw", "bjerksund", "tree"]
@@ -20,7 +18,7 @@ EngineKey = Literal["analytic", "fd", "baw", "bjerksund", "tree"]
 
 class FXOption(ClientPosition):
     """
-    Thin adapter around the RVS EquityOption wrapper, but using *price/base* terminology.
+    Thin adapter around the portfolio engine EquityOption wrapper, but using *price/base* terminology.
 
     Spot mapping:
       fx_spot = price_ccy_rate / base_ccy_rate
@@ -68,14 +66,8 @@ class FXOption(ClientPosition):
         self.posName = pos_name
 
         # normalize valuation date
-        self.valueDate = (
-            value_date
-            if isinstance(value_date, date)
-            else date.fromisoformat(value_date)
-        )
-        self.ql_value_date = Date(
-            self.valueDate.day, self.valueDate.month, self.valueDate.year
-        )
+        self.valueDate = value_date if isinstance(value_date, date) else date.fromisoformat(value_date)
+        self.ql_value_date = Date(self.valueDate.day, self.valueDate.month, self.valueDate.year)
 
         # FX spot components (price/base)
         self.baseCCY = spot["base_ccy"]
@@ -114,8 +106,8 @@ class FXOption(ClientPosition):
 
     # ------------- core valuation -------------
     def valuePosition(self) -> float:
-        """Build an RVS EquityOption with mapped inputs and delegate pricing."""
-        eq = RVSEquityOption(
+        """Build a portfolio EquityOption with mapped inputs and delegate pricing."""
+        eq = PortfolioEquityOption(
             **self._eq_kwargs,
             spot=self.fx_spot,
             discount_curve=self._price_discount_curve,  # r (price currency)

--- a/portfolioengine/positions/interest_rate_swap.py
+++ b/portfolioengine/positions/interest_rate_swap.py
@@ -4,29 +4,30 @@ from datetime import date
 
 import numpy as np
 from QuantLib import (
-    Date,
-    Period,
     TARGET,
     Actual360,
+    Date,
+    Period,
     YieldTermStructureHandle,
     as_floating_rate_coupon,
 )
+
 from pricingengine.cashflows.swap_leg import FixedLeg, FloatingLeg
 from pricingengine.instruments.interest_rate_swap import InterestRateSwap
 
-from rvs_engine_interface.client_positions.QL_Mapping import (
+from ..data_structures.market_data_mapper import MarketDataMapper
+from ..data_structures.QL_Mapping import (
     QL_day_count_mapper,
     QL_swap_leg_mapper,
     generic_ibor,
+    ql_eval_date,
 )
-from rvs_engine_interface.client_positions.QL_Mapping import ql_eval_date
-from rvs_engine_interface.client_positions.client_positions import ClientPosition
-from rvs_engine_interface.client_positions.market_data_mapper import MarketDataMapper
+from .client_positions import ClientPosition
 
 
 class IRS(ClientPosition):
     """
-    RVS wrapper around pricingengine.InterestRateSwap.
+    Portfolio engine wrapper around pricingengine.InterestRateSwap.
 
     - Uses QuantLib global Settings.evaluationDate via ql_eval_date().
     - Builds legs using pricingengine swap-leg classes (via QL_swap_leg_mapper).
@@ -53,30 +54,14 @@ class IRS(ClientPosition):
         self.ccy = ccy
 
         # Parse dates (accepts ISO strings or date objects)
-        self.valueDate = (
-            value_date
-            if isinstance(value_date, date)
-            else date.fromisoformat(value_date)
-        )
-        self.issue_date = (
-            issue_date
-            if isinstance(issue_date, date)
-            else date.fromisoformat(issue_date)
-        )
-        self.maturity = (
-            maturity if isinstance(maturity, date) else date.fromisoformat(maturity)
-        )
+        self.valueDate = value_date if isinstance(value_date, date) else date.fromisoformat(value_date)
+        self.issue_date = issue_date if isinstance(issue_date, date) else date.fromisoformat(issue_date)
+        self.maturity = maturity if isinstance(maturity, date) else date.fromisoformat(maturity)
 
         # QuantLib Date views
-        self.ql_value_date = Date(
-            self.valueDate.day, self.valueDate.month, self.valueDate.year
-        )
-        self.ql_issue_date = Date(
-            self.issue_date.day, self.issue_date.month, self.issue_date.year
-        )
-        self.ql_maturity = Date(
-            self.maturity.day, self.maturity.month, self.maturity.year
-        )
+        self.ql_value_date = Date(self.valueDate.day, self.valueDate.month, self.valueDate.year)
+        self.ql_issue_date = Date(self.issue_date.day, self.issue_date.month, self.issue_date.year)
+        self.ql_maturity = Date(self.maturity.day, self.maturity.month, self.maturity.year)
 
         # Day count to build curves (stays local to this wrapper; legs use their own DC)
         self.ql_curve_day_count = Actual360()
@@ -144,16 +129,12 @@ class IRS(ClientPosition):
         fl_coupons = floating_leg.cashflows
         if not fl_coupons:
             return
-        fixing_dates = tuple(
-            as_floating_rate_coupon(cf).fixingDate() for cf in fl_coupons
-        )
+        fixing_dates = tuple(as_floating_rate_coupon(cf).fixingDate() for cf in fl_coupons)
         past_fixings = [d for d in fixing_dates if d < self.ql_value_date]
         if not past_fixings:
             return
         last_fixing_date = past_fixings[-1]
-        index.addFixing(
-            last_fixing_date, float(self.paying_leg_spec["curr_fixing"]), True
-        )
+        index.addFixing(last_fixing_date, float(self.paying_leg_spec["curr_fixing"]), True)
 
     def _get_used_risk_factors(self) -> dict:
         """
@@ -162,9 +143,7 @@ class IRS(ClientPosition):
         if self.cash_flows is None:
             return {}
         return_dict = self.cash_flows.reset_index().to_dict(orient="list")
-        if self.paying_leg_type == "amortized_floating" and hasattr(
-            self.paying_leg_ql, "nominals"
-        ):
+        if self.paying_leg_type == "amortized_floating" and hasattr(self.paying_leg_ql, "nominals"):
             return_dict["nominals"] = self.paying_leg_ql.nominals
         return return_dict
 
@@ -205,9 +184,7 @@ class IRS(ClientPosition):
         # For floating variants, supply a placeholder index; we’ll rebind in MTM.
         if leg_data["leg_type"] in ("floating", "amortized_floating"):
             placeholder_handle = YieldTermStructureHandle()  # empty link placeholder
-            kwargs["index"] = generic_ibor(
-                leg_data["tenor"], self.ccy, placeholder_handle
-            )
+            kwargs["index"] = generic_ibor(leg_data["tenor"], self.ccy, placeholder_handle)
 
         # Optional fields with light transformations
         for key in (
@@ -246,9 +223,7 @@ class IRS(ClientPosition):
             ql_discount_handle, ql_forecast_handle = self._build_curve_handles()
 
             # 3) Real index on the forecast curve (use paying leg tenor)
-            forecast_index = generic_ibor(
-                self.paying_leg_spec["tenor"], self.ccy, ql_forecast_handle
-            )
+            forecast_index = generic_ibor(self.paying_leg_spec["tenor"], self.ccy, ql_forecast_handle)
 
             # 4) Bind index to the floating leg (mapping guarantees paying is floating in our uses)
             self.paying_leg_ql = self.paying_leg_ql.with_index(forecast_index)

--- a/portfolioengine/risk_engine/__init__.py
+++ b/portfolioengine/risk_engine/__init__.py
@@ -1,0 +1,5 @@
+"""Risk engine stubs for the portfolio engine."""
+
+from .risk_engine_interface import InitializeRiskEngine
+
+__all__ = ["InitializeRiskEngine"]

--- a/portfolioengine/risk_engine/risk_engine_interface.py
+++ b/portfolioengine/risk_engine/risk_engine_interface.py
@@ -1,0 +1,28 @@
+"""Minimal risk engine stub used by the portfolio engine registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class InitializeRiskEngine:
+    """Placeholder implementation for the portfolio risk engine.
+
+    The original project integrates with a proprietary risk engine.  For the
+    open-source version we keep the public interface but raise an explicit
+    error when the portfolio specific metrics are requested.  This keeps the
+    import structure intact while signalling clearly that the functionality is
+    not yet implemented.
+    """
+
+    def get_portfolio_var(self, *args, **kwargs):  # noqa: D401 - keep signature flexible
+        """Placeholder for Value-at-Risk calculation.
+
+        The production system would return a Value-at-Risk figure together with
+        diagnostics.  The current implementation raises ``NotImplementedError``
+        to make it obvious to callers that the behaviour is not available in
+        this repository.
+        """
+
+        raise NotImplementedError("Portfolio VaR computation is not implemented in the open-source portfolio engine.")

--- a/pricingengine/math/__init__.py
+++ b/pricingengine/math/__init__.py
@@ -1,0 +1,5 @@
+"""Mathematical utilities for the pricing engine."""
+
+from .finite_difference import central_difference
+
+__all__ = ["central_difference"]

--- a/pricingengine/math/finite_difference.py
+++ b/pricingengine/math/finite_difference.py
@@ -1,0 +1,31 @@
+"""Finite difference helper utilities."""
+
+from __future__ import annotations
+
+
+def central_difference(f_plus: float, f_minus: float, increment: float) -> float:
+    """Compute the central difference derivative estimate.
+
+    Parameters
+    ----------
+    f_plus:
+        Function value at ``x + increment``.
+    f_minus:
+        Function value at ``x - increment``.
+    increment:
+        The increment size. Must be non-zero.
+
+    Returns
+    -------
+    float
+        The central difference ``(f_plus - f_minus) / (2 * increment)``.
+
+    Raises
+    ------
+    ValueError
+        If ``increment`` is zero.
+    """
+
+    if increment == 0:
+        raise ValueError("'increment' cannot be zero")
+    return (f_plus - f_minus) / (2 * increment)

--- a/pricingengine/termstructures/__init__.py
+++ b/pricingengine/termstructures/__init__.py
@@ -1,3 +1,4 @@
+from .curve import Curve
 from .curve_nodes import CurveNodes
 
-__all__ = ["CurveNodes"]
+__all__ = ["Curve", "CurveNodes"]

--- a/pricingengine/termstructures/curve.py
+++ b/pricingengine/termstructures/curve.py
@@ -1,0 +1,29 @@
+"""Minimal curve container used by the portfolio engine adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+import QuantLib as ql
+
+
+@dataclass(frozen=True)
+class Curve:
+    """Lightweight container for curve data points."""
+
+    dates: Tuple[ql.Date, ...]
+    day_counter: ql.DayCounter
+    quotes: Tuple[float, ...]
+
+    def __init__(
+        self, *, dates: Sequence[ql.Date], day_counter: ql.DayCounter, quotes: Sequence[float]
+    ) -> None:
+        object.__setattr__(self, "dates", tuple(dates))
+        object.__setattr__(self, "day_counter", day_counter)
+        object.__setattr__(self, "quotes", tuple(quotes))
+
+    def to_zero_curve(self) -> ql.ZeroCurve:
+        """Build a QuantLib zero curve from the stored data."""
+
+        return ql.ZeroCurve(list(self.dates), list(self.quotes), self.day_counter)

--- a/pricingengine/termstructures/curve_nodes.py
+++ b/pricingengine/termstructures/curve_nodes.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, replace
+from functools import cached_property
+from math import exp, log
+from typing import Literal, Sequence
+
 from QuantLib import (
     Date,
     DayCounter,
@@ -11,10 +16,6 @@ from QuantLib import (
     YieldTermStructureHandle,
     ZeroCurve,
 )
-from dataclasses import dataclass, replace
-from functools import cached_property
-from math import exp, log
-from typing import Literal, Sequence
 
 QuoteKind = Literal["zero", "discount", "forward", "flat"]
 CurveRole = Literal["discounting", "forecasting", "other"]

--- a/rvs_engine_interface/__init__.py
+++ b/rvs_engine_interface/__init__.py
@@ -1,0 +1,43 @@
+"""Compatibility layer exposing the portfolio engine under the legacy name."""
+
+from portfolioengine import (
+    IRS,
+    ClientPosition,
+    EquityOption,
+    FXForward,
+    FXOption,
+    Repo,
+    computation,
+    compute,
+    compute_instrument,
+    compute_portfolio,
+    factor_utils,
+    get_engine_class,
+    get_engine_metric_function,
+    get_factors,
+    get_instrument_class,
+    get_metric_function,
+    instrument_registry,
+    portfolio_engine_registry,
+)
+
+__all__ = [
+    "ClientPosition",
+    "EquityOption",
+    "FXForward",
+    "FXOption",
+    "IRS",
+    "Repo",
+    "computation",
+    "compute",
+    "compute_instrument",
+    "compute_portfolio",
+    "factor_utils",
+    "get_engine_class",
+    "get_engine_metric_function",
+    "get_factors",
+    "get_instrument_class",
+    "get_metric_function",
+    "instrument_registry",
+    "portfolio_engine_registry",
+]


### PR DESCRIPTION
## Summary
- replace the remaining `rvs_engine_interface` imports in the portfolio engine with package-local imports and add the missing `__init__.py` files
- provide a stub risk-engine module and a compatibility package that exposes the portfolio engine under the legacy `rvs_engine_interface` name
- add minimal math and term-structure helpers so dependent modules can import pricing-engine utilities without missing-module errors

## Testing
- `pytest` *(fails: missing `pricingengine.cashflows` package required by upstream tests)*
- `ruff format`
- `ruff check` *(fails: existing style violations across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e270bf6f50832f993400b3d17e32b6