### PR TITLE
Cache QuantLib primitives for options and swaps

### DIFF
--- a/PricingEngine/Instruments/Common/_option.py
+++ b/PricingEngine/Instruments/Common/_option.py
@@ -42,6 +42,12 @@ class Option(Instrument, ABC):
     quantity: int
     contract_size: int = 1  # set to 100 in equity options; 1 for FX/index by default
 
+    # cached QuantLib primitives (lazily built)
+    _ql_opt_cache: QLVanillaOption | None = field(default=None, init=False, repr=False, compare=False)
+    _engine_cache: Any | None = field(default=None, init=False, repr=False, compare=False)
+    _process_cache: BlackScholesMertonProcess | None = field(default=None, init=False, repr=False, compare=False)
+    _cache_eval_date: Date | None = field(default=None, init=False, repr=False, compare=False)
+
     # ---------- timeline / identity ----------
     @property
     def valuation_date(self) -> Date:
@@ -70,19 +76,45 @@ class Option(Instrument, ABC):
     @abstractmethod
     def _process(self) -> BlackScholesMertonProcess: ...
 
-    @abstractmethod
-    def npv_per_unit(self) -> float: ...
+    def _make_process(self) -> BlackScholesMertonProcess:
+        return self._process()
+
+    def _clear_cache(self) -> None:
+        object.__setattr__(self, "_ql_opt_cache", None)
+        object.__setattr__(self, "_engine_cache", None)
+        object.__setattr__(self, "_process_cache", None)
+        object.__setattr__(self, "_cache_eval_date", None)
+
+    def _ensure_built(self) -> None:
+        eval_date = Settings.instance().evaluationDate
+        if self._ql_opt_cache is not None and self._cache_eval_date == eval_date:
+            return
+
+        process = self._make_process()
+        engine = self._engine(process)
+        ql_option = QLVanillaOption(self._payoff, self._exercise)
+        ql_option.setPricingEngine(engine)
+
+        object.__setattr__(self, "_process_cache", process)
+        object.__setattr__(self, "_engine_cache", engine)
+        object.__setattr__(self, "_ql_opt_cache", ql_option)
+        object.__setattr__(self, "_cache_eval_date", eval_date)
 
     def _ql_option(self) -> QLVanillaOption:
-        opt = QLVanillaOption(self._payoff, self._exercise())
-        opt.setPricingEngine(self._engine)
-        return opt
+        self._ensure_built()
+        assert self._ql_opt_cache is not None  # for mypy / linters
+        return self._ql_opt_cache
 
     def _position_multiplier(self) -> int:
         # uniform scaling across Instruments
         return int(self.quantity) * int(self.contract_size)
 
     # ---------- public API ----------
+    def npv_per_unit(self) -> float:
+        if self.is_expired:
+            return 0.0
+        return float(self._ql_option().NPV())
+
     def npv(self) -> float:
         return self._position_multiplier() * self.npv_per_unit()
 

--- a/PricingEngine/Instruments/equity_option.py
+++ b/PricingEngine/Instruments/equity_option.py
@@ -115,19 +115,9 @@ class EquityOption(Option):
     def _process(self) -> BlackScholesMertonProcess:
         return BlackScholesMertonProcess(self.spot, self.dividend_curve, self.risk_free_curve, self.vol)
 
-    def _ql_option(self) -> QLVanillaOption:
-        ql = QLVanillaOption(self._payoff, self._exercise)
-        ql.setPricingEngine(self._engine(self._process()))
-        return ql
-
     def _position_multiplier(self) -> float:
         # OPTION convention: per-position = per-unit * quantity * contract_size
         return float(self.quantity) * float(self.contract_size)
-
-    def npv_per_unit(self) -> float:
-        if self.is_expired:
-            return 0.0
-        return float(self._ql_option().NPV())
 
     # ------------- finite-difference bump helper -------------
     _EPS_S_REL = 1e-4

--- a/PricingEngine/Instruments/interest_rate_swap.py
+++ b/PricingEngine/Instruments/interest_rate_swap.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 
 from pandas import DataFrame, merge
@@ -44,6 +44,11 @@ class InterestRateSwap(Instrument):
     paying_leg: FixedLeg | FloatingLeg
     receiving_leg: FixedLeg | FloatingLeg
     discount_curve: YieldTermStructureHandle  # required; can be Relinkable
+
+    _swap_cache: Swap | None = field(default=None, init=False, repr=False, compare=False)
+    _swap_cache_eval: Date | None = field(default=None, init=False, repr=False, compare=False)
+    _vanilla_cache: VanillaSwap | None = field(default=None, init=False, repr=False, compare=False)
+    _vanilla_cache_eval: Date | None = field(default=None, init=False, repr=False, compare=False)
 
     # ---------- lifecycle & invariants ----------
     def __post_init__(self):
@@ -112,7 +117,23 @@ class InterestRateSwap(Instrument):
             return self.paying_leg
         raise RuntimeError(f"swap is missing {cls.__name__}")
 
-    def _swap_ql(self) -> Swap:
+    def _build_swap(self) -> Swap:
+        pay = self.paying_leg.cashflows
+        rec = self.receiving_leg.cashflows
+        swap = Swap(pay, rec)
+        swap.setPricingEngine(self.discount_engine)
+        return swap
+
+    def _ensure_swap_cache(self) -> Swap:
+        eval_date = self.valuation_date
+        if self._swap_cache is None or self._swap_cache_eval != eval_date:
+            swap = self._build_swap()
+            object.__setattr__(self, "_swap_cache", swap)
+            object.__setattr__(self, "_swap_cache_eval", eval_date)
+        assert self._swap_cache is not None
+        return self._swap_cache
+
+    def _ql_swap(self) -> Swap:
         """
         Returns a QuantLib `Swap` object.
 
@@ -125,25 +146,9 @@ class InterestRateSwap(Instrument):
 
         This method is a part of valuation framework for IRS.
         """
-        pay = self.paying_leg.cashflows
-        rec = self.receiving_leg.cashflows
-        sw = Swap(pay, rec)
-        sw.setPricingEngine(self.discount_engine)
-        return sw
+        return self._ensure_swap_cache()
 
-    def _vanilla_swap_ql(self) -> VanillaSwap:
-        """
-        Returns a QuantLib `VanillaSwap` object.
-
-        `VanillaSwap` is a native QuantLib object that has `NPV` method,
-        similar to `Swap` object, that can be used for pricing of vanilla
-        interest-rate swaps (IRS). However, `VanillaSwap` does not have support
-        amortization nor interest-rate leverage and therefore is not used for
-        IRS valuation.
-
-        `VanillaSwap` object also includes `fairRate` and `fairSpread` methods
-        and is therefore used for construction and valuation of swaptions.
-        """
+    def _build_vanilla_swap(self) -> VanillaSwap:
         swap_type = VanillaSwap.Payer if (self.fixed_leg is self.paying_leg) else VanillaSwap.Receiver
         fs = self.fixed_leg.future_schedule
         fls = self.floating_leg.future_schedule
@@ -167,32 +172,55 @@ class InterestRateSwap(Instrument):
         vs.setPricingEngine(self.discount_engine)
         return vs
 
+    def _ensure_vanilla_cache(self) -> VanillaSwap:
+        eval_date = self.valuation_date
+        if self._vanilla_cache is None or self._vanilla_cache_eval != eval_date:
+            vanilla = self._build_vanilla_swap()
+            object.__setattr__(self, "_vanilla_cache", vanilla)
+            object.__setattr__(self, "_vanilla_cache_eval", eval_date)
+        assert self._vanilla_cache is not None
+        return self._vanilla_cache
+
+    def _ql_vanilla_swap(self) -> VanillaSwap:
+        """
+        Returns a QuantLib `VanillaSwap` object.
+
+        `VanillaSwap` is a native QuantLib object that has `NPV` method,
+        similar to `Swap` object, that can be used for pricing of vanilla
+        interest-rate swaps (IRS). However, `VanillaSwap` does not have support
+        amortization nor interest-rate leverage and therefore is not used for
+        IRS valuation.
+
+        `VanillaSwap` object also includes `fairRate` and `fairSpread` methods
+        and is therefore used for construction and valuation of swaptions.
+        """
+        return self._ensure_vanilla_cache()
+
     def vanilla(self) -> VanillaSwap:  # needed for Swaption
-        vs = self._vanilla_swap_ql()
-        return vs
+        return self._ql_vanilla_swap()
 
     # ---------- public API ----------
     def npv(self) -> float:
         if self.is_expired:
             return 0.0
-        return self._swap_ql().NPV()
+        return self._ql_swap().NPV()
 
     def pv01(self) -> float:
         """Fixed-leg PV01 (coupon BPV): ΔNPV for +1 bp in the fixed coupon."""
         leg_index = 0 if (self.fixed_leg is self.paying_leg) else 1
-        return self._swap_ql().legBPS(leg_index)
+        return self._ql_swap().legBPS(leg_index)
 
     def dv01(self) -> float:
         """Floating-leg BPV to spread: ΔNPV for +1 bp in the floating spread."""
         leg_index = 0 if (self.floating_leg is self.paying_leg) else 1
-        return self._swap_ql().legBPS(leg_index)
+        return self._ql_swap().legBPS(leg_index)
 
     def ir01_discount(self, bump_bp: float = 1.0) -> float:
         """
         Curve BPV to a parallel bump of the *discounting* curve (in zero-yield terms).
         Positive means NPV rises when discount rates fall.
         """
-        base = self._swap_ql().NPV()
+        base = self._ql_swap().NPV()
 
         # Build a spreaded curve on top of the current discount handle.
         spread = QuoteHandle(SimpleQuote(bump_bp / 10_000.0))
@@ -219,7 +247,7 @@ class InterestRateSwap(Instrument):
         Curve BPV to a parallel bump of the *forecasting* (index) curve.
         Uses the floating leg's IborIndex forwarding handle; no external nodes.
         """
-        base = self._swap_ql().NPV()
+        base = self._ql_swap().NPV()
 
         # Bump the index's forwarding TS via a zero-spread wrapper.
         idx0 = self.floating_leg.index
@@ -248,7 +276,7 @@ class InterestRateSwap(Instrument):
     # ---------- diagnostics ----------
     def cashflow_table(self) -> DataFrame:
         """Bloomberg-style cashflow breakdown using the bound discount curve."""
-        sw = self._swap_ql()
+        sw = self._ql_swap()
         df_pay = DataFrame(data=({"Date": c.date(), "Pay": -c.amount()} for c in sw.leg(0)))
         df_rec = DataFrame(data=({"Date": c.date(), "Receive": c.amount()} for c in sw.leg(1)))
 

--- a/PricingEngine/Instruments/swaption.py
+++ b/PricingEngine/Instruments/swaption.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from QuantLib import (
     BachelierSwaptionEngine,
@@ -33,6 +33,8 @@ from QuantLib import (
 from QuantLib import (
     Swaption as QLSwaption,
 )
+
+from typing import Any
 
 from PricingEngine.Instruments import InterestRateSwap
 from PricingEngine.Instruments.Common import Instrument
@@ -70,6 +72,13 @@ class Swaption(Instrument):
     hw_sigma: float | None = None
     hw_time_steps: int = 80
     time_grid: TimeGrid | None = None
+
+    _swaption_cache: QLSwaption | None = field(default=None, init=False, repr=False, compare=False)
+    _engine_cache: Any | None = field(default=None, init=False, repr=False, compare=False)
+    _hw_model_cache: HullWhite | None = field(default=None, init=False, repr=False, compare=False)
+    _cache_eval_date: Date | None = field(default=None, init=False, repr=False, compare=False)
+    _vol_link_cache: SwaptionVolatilityStructure | None = field(default=None, init=False, repr=False, compare=False)
+    _engine_kind_cache: str | None = field(default=None, init=False, repr=False, compare=False)
 
     def __post_init__(self):
         # Important: when receiving a cube through a handle link, QL SWIG does not downcast to Cube class
@@ -176,13 +185,13 @@ class Swaption(Instrument):
         # NOTE: in practice you might want calendar.advance(irs.issue_date, -index.fixingDays(), ...)
         return [self.irs.issue_date]
 
-    def _exercise_ql(self):
+    def _ql_exercise(self):
         exps = self._expiries()
         if len(exps) == 1:
             return EuropeanExercise(exps[0])
         return BermudanExercise(list(exps))
 
-    def _settlement_ql(self):
+    def _ql_settlement(self):
         return Settlement.Physical if self.settlement.lower() == "physical" else Settlement.Cash
 
     def _engine_european(self):
@@ -197,15 +206,7 @@ class Swaption(Instrument):
         raise ValueError("vol_type must be 'black' or 'bachelier'")
 
     def _engine_bermudan(self):
-        # Use provided params if given; otherwise calibrate to the surface
-        if self.hw_a is None or self.hw_sigma is None:
-            model = self._calibrate_hw()
-        else:
-            model = HullWhite(self.irs.discount_curve, float(self.hw_a), float(self.hw_sigma))
-
-        if self.time_grid is not None:
-            return TreeSwaptionEngine(model, self.time_grid, self.irs.discount_curve)
-        return TreeSwaptionEngine(model, int(self.hw_time_steps), self.irs.discount_curve)
+        return self._build_tree_engine()
 
     def _use_tree(self) -> bool:
         if self.engine == "hw":
@@ -213,6 +214,9 @@ class Swaption(Instrument):
         if self.engine == "surface":
             return False
         return len(self._expiries()) > 1
+
+    def _engine_kind(self) -> str:
+        return "tree" if self._use_tree() else "surface"
 
     # --- option tenor -> option date (on index calendar) ---
     def _option_date_from_tenor(self, opt_tenor: Period) -> Date:
@@ -383,21 +387,74 @@ class Swaption(Instrument):
         model.calibrate(helpers, method, end)
         return model
 
-    def _swaption_ql(self) -> QLSwaption:
-        ex = self._exercise_ql()
-        swaption = QLSwaption(self.irs.vanilla(), ex, self._settlement_ql())
+    def _build_tree_engine(self) -> TreeSwaptionEngine:
+        eval_date = self.valuation_date
+        vol_link = self.vol_surface.currentLink()
+        cached_tree = (
+            isinstance(self._engine_cache, TreeSwaptionEngine)
+            and self._engine_kind_cache == "tree"
+            and self._cache_eval_date == eval_date
+            and self._vol_link_cache is vol_link
+        )
+        if cached_tree:
+            return self._engine_cache
 
-        if self._use_tree():
-            swaption.setPricingEngine(self._engine_bermudan())
+        if self.hw_a is None or self.hw_sigma is None:
+            model = self._calibrate_hw()
         else:
-            swaption.setPricingEngine(self._engine_european())
+            model = HullWhite(self.irs.discount_curve, float(self.hw_a), float(self.hw_sigma))
+
+        if self.time_grid is not None:
+            engine = TreeSwaptionEngine(model, self.time_grid, self.irs.discount_curve)
+        else:
+            engine = TreeSwaptionEngine(model, int(self.hw_time_steps), self.irs.discount_curve)
+
+        object.__setattr__(self, "_hw_model_cache", model)
+        object.__setattr__(self, "_engine_cache", engine)
+        object.__setattr__(self, "_cache_eval_date", eval_date)
+        object.__setattr__(self, "_vol_link_cache", vol_link)
+        object.__setattr__(self, "_engine_kind_cache", "tree")
+        return engine
+
+    def _ensure_swaption(self) -> QLSwaption:
+        eval_date = self.valuation_date
+        vol_link = self.vol_surface.currentLink()
+        engine_kind = self._engine_kind()
+
+        if (
+            self._swaption_cache is not None
+            and self._cache_eval_date == eval_date
+            and self._vol_link_cache is vol_link
+            and self._engine_kind_cache == engine_kind
+        ):
+            return self._swaption_cache
+
+        exercise = self._ql_exercise()
+        vanilla = self.irs.vanilla()
+        swaption = QLSwaption(vanilla, exercise, self._ql_settlement())
+
+        if engine_kind == "tree":
+            engine = self._build_tree_engine()
+        else:
+            engine = self._engine_european()
+            object.__setattr__(self, "_engine_cache", engine)
+
+        swaption.setPricingEngine(engine)
+
+        object.__setattr__(self, "_swaption_cache", swaption)
+        object.__setattr__(self, "_cache_eval_date", eval_date)
+        object.__setattr__(self, "_vol_link_cache", vol_link)
+        object.__setattr__(self, "_engine_kind_cache", engine_kind)
         return swaption
+
+    def _ql_swaption(self) -> QLSwaption:
+        return self._ensure_swaption()
 
     # ---------- public API ----------
     def npv(self) -> float:
         if self.is_expired:
             return 0.0
-        npv = float(self._swaption_ql().NPV())
+        npv = float(self._ql_swaption().NPV())
         return npv if self.is_long else -npv
 
     def implied_volatility(
@@ -417,7 +474,7 @@ class Swaption(Instrument):
 
         # Build the payoff vanilla (with strike if provided)
         v = self.irs.vanilla()
-        swaption = QLSwaption(v, self._exercise_ql(), self._settlement_ql())
+        swaption = QLSwaption(v, self._ql_exercise(), self._ql_settlement())
 
         # Exact whole-month swap length from the underlying vanilla schedule
         sch = v.fixedSchedule()

--- a/tests/PricingEngine/Instruments/test_interest_rate_swap.py
+++ b/tests/PricingEngine/Instruments/test_interest_rate_swap.py
@@ -363,7 +363,7 @@ class TestD_MarkToMarket:
 class TestE_VanillaEquivalence:
     def test_vanilla_swap_metrics_match(self, fixed_leg, floating_leg, discount_yts):
         """
-        _vanilla_swap_ql should match NPV and leg BPS used by the IRS wrapper.
+        _ql_vanilla_swap should match NPV and leg BPS used by the IRS wrapper.
         """
         with SavedSettings():
             Settings.instance().evaluationDate = Date(5, 5, 2024)
@@ -376,7 +376,7 @@ class TestE_VanillaEquivalence:
             pv01 = swap.pv01()
             dv01 = swap.dv01()
 
-            vs = swap._vanilla_swap_ql()
+            vs = swap._ql_vanilla_swap()
             assert npv == vs.NPV()
             assert pv01 == vs.fixedLegBPS()
             assert dv01 == vs.floatingLegBPS()


### PR DESCRIPTION
## Summary
- add lazy caches to the common option base class so engines, processes, and VanillaOption wrappers are reused across valuations
- remove redundant overrides from equity options to consume the shared caching logic
- memoize swap and vanilla swap wrappers and reuse calibrated engines when building swaptions
- rename QuantLib helper accessors so their `_ql_` prefix appears at the start consistently

## Testing
- ruff format .
- ruff check . *(fails: repository has existing lint violations in tests)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e3c8ae5b00832f90b57cb06595d5f0