### PR TITLE
Rename internal QuantLib helpers to ql prefix

### DIFF
--- a/PricingEngine/Instruments/interest_rate_swap.py
+++ b/PricingEngine/Instruments/interest_rate_swap.py
@@ -112,7 +112,7 @@ class InterestRateSwap(Instrument):
             return self.paying_leg
         raise RuntimeError(f"swap is missing {cls.__name__}")
 
-    def _swap_ql(self) -> Swap:
+    def _ql_swap(self) -> Swap:
         """
         Returns a QuantLib `Swap` object.
 
@@ -131,7 +131,7 @@ class InterestRateSwap(Instrument):
         sw.setPricingEngine(self.discount_engine)
         return sw
 
-    def _vanilla_swap_ql(self) -> VanillaSwap:
+    def _ql_vanilla_swap(self) -> VanillaSwap:
         """
         Returns a QuantLib `VanillaSwap` object.
 
@@ -168,31 +168,31 @@ class InterestRateSwap(Instrument):
         return vs
 
     def vanilla(self) -> VanillaSwap:  # needed for Swaption
-        vs = self._vanilla_swap_ql()
+        vs = self._ql_vanilla_swap()
         return vs
 
     # ---------- public API ----------
     def npv(self) -> float:
         if self.is_expired:
             return 0.0
-        return self._swap_ql().NPV()
+        return self._ql_swap().NPV()
 
     def pv01(self) -> float:
         """Fixed-leg PV01 (coupon BPV): ΔNPV for +1 bp in the fixed coupon."""
         leg_index = 0 if (self.fixed_leg is self.paying_leg) else 1
-        return self._swap_ql().legBPS(leg_index)
+        return self._ql_swap().legBPS(leg_index)
 
     def dv01(self) -> float:
         """Floating-leg BPV to spread: ΔNPV for +1 bp in the floating spread."""
         leg_index = 0 if (self.floating_leg is self.paying_leg) else 1
-        return self._swap_ql().legBPS(leg_index)
+        return self._ql_swap().legBPS(leg_index)
 
     def ir01_discount(self, bump_bp: float = 1.0) -> float:
         """
         Curve BPV to a parallel bump of the *discounting* curve (in zero-yield terms).
         Positive means NPV rises when discount rates fall.
         """
-        base = self._swap_ql().NPV()
+        base = self._ql_swap().NPV()
 
         # Build a spreaded curve on top of the current discount handle.
         spread = QuoteHandle(SimpleQuote(bump_bp / 10_000.0))
@@ -219,7 +219,7 @@ class InterestRateSwap(Instrument):
         Curve BPV to a parallel bump of the *forecasting* (index) curve.
         Uses the floating leg's IborIndex forwarding handle; no external nodes.
         """
-        base = self._swap_ql().NPV()
+        base = self._ql_swap().NPV()
 
         # Bump the index's forwarding TS via a zero-spread wrapper.
         idx0 = self.floating_leg.index
@@ -248,7 +248,7 @@ class InterestRateSwap(Instrument):
     # ---------- diagnostics ----------
     def cashflow_table(self) -> DataFrame:
         """Bloomberg-style cashflow breakdown using the bound discount curve."""
-        sw = self._swap_ql()
+        sw = self._ql_swap()
         df_pay = DataFrame(data=({"Date": c.date(), "Pay": -c.amount()} for c in sw.leg(0)))
         df_rec = DataFrame(data=({"Date": c.date(), "Receive": c.amount()} for c in sw.leg(1)))
 

--- a/PricingEngine/Instruments/swaption.py
+++ b/PricingEngine/Instruments/swaption.py
@@ -176,13 +176,13 @@ class Swaption(Instrument):
         # NOTE: in practice you might want calendar.advance(irs.issue_date, -index.fixingDays(), ...)
         return [self.irs.issue_date]
 
-    def _exercise_ql(self):
+    def _ql_exercise(self):
         exps = self._expiries()
         if len(exps) == 1:
             return EuropeanExercise(exps[0])
         return BermudanExercise(list(exps))
 
-    def _settlement_ql(self):
+    def _ql_settlement(self):
         return Settlement.Physical if self.settlement.lower() == "physical" else Settlement.Cash
 
     def _engine_european(self):
@@ -383,9 +383,9 @@ class Swaption(Instrument):
         model.calibrate(helpers, method, end)
         return model
 
-    def _swaption_ql(self) -> QLSwaption:
-        ex = self._exercise_ql()
-        swaption = QLSwaption(self.irs.vanilla(), ex, self._settlement_ql())
+    def _ql_swaption(self) -> QLSwaption:
+        ex = self._ql_exercise()
+        swaption = QLSwaption(self.irs.vanilla(), ex, self._ql_settlement())
 
         if self._use_tree():
             swaption.setPricingEngine(self._engine_bermudan())
@@ -397,7 +397,7 @@ class Swaption(Instrument):
     def npv(self) -> float:
         if self.is_expired:
             return 0.0
-        npv = float(self._swaption_ql().NPV())
+        npv = float(self._ql_swaption().NPV())
         return npv if self.is_long else -npv
 
     def implied_volatility(
@@ -417,7 +417,7 @@ class Swaption(Instrument):
 
         # Build the payoff vanilla (with strike if provided)
         v = self.irs.vanilla()
-        swaption = QLSwaption(v, self._exercise_ql(), self._settlement_ql())
+        swaption = QLSwaption(v, self._ql_exercise(), self._ql_settlement())
 
         # Exact whole-month swap length from the underlying vanilla schedule
         sch = v.fixedSchedule()

--- a/tests/PricingEngine/Instruments/test_interest_rate_swap.py
+++ b/tests/PricingEngine/Instruments/test_interest_rate_swap.py
@@ -363,7 +363,7 @@ class TestD_MarkToMarket:
 class TestE_VanillaEquivalence:
     def test_vanilla_swap_metrics_match(self, fixed_leg, floating_leg, discount_yts):
         """
-        _vanilla_swap_ql should match NPV and leg BPS used by the IRS wrapper.
+        _ql_vanilla_swap should match NPV and leg BPS used by the IRS wrapper.
         """
         with SavedSettings():
             Settings.instance().evaluationDate = Date(5, 5, 2024)
@@ -376,7 +376,7 @@ class TestE_VanillaEquivalence:
             pv01 = swap.pv01()
             dv01 = swap.dv01()
 
-            vs = swap._vanilla_swap_ql()
+            vs = swap._ql_vanilla_swap()
             assert npv == vs.NPV()
             assert pv01 == vs.fixedLegBPS()
             assert dv01 == vs.floatingLegBPS()


### PR DESCRIPTION
## Summary
- rename protected interest rate swap QuantLib helpers to the `_ql_` prefix for consistent naming
- update swaption helpers to the new `_ql_` naming convention and adjust their usages
- align interest rate swap tests with the renamed helper for vanilla swap access

## Testing
- ruff format PricingEngine/Instruments/interest_rate_swap.py PricingEngine/Instruments/swaption.py tests/PricingEngine/Instruments/test_interest_rate_swap.py
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e3e59d6af4832fa8106420aad520aa