### PR TITLE
Cache QuantLib options for repeated valuations

### DIFF
--- a/PricingEngine/Instruments/Common/_option.py
+++ b/PricingEngine/Instruments/Common/_option.py
@@ -42,6 +42,11 @@ class Option(Instrument, ABC):
     quantity: int
     contract_size: int = 1  # set to 100 in equity options; 1 for FX/index by default
 
+    _ql_option_cache: QLVanillaOption | None = field(default=None, init=False, repr=False, compare=False)
+    _engine_cache: Any | None = field(default=None, init=False, repr=False, compare=False)
+    _process_cache: BlackScholesMertonProcess | None = field(default=None, init=False, repr=False, compare=False)
+    _cache_eval_date: Date | None = field(default=None, init=False, repr=False, compare=False)
+
     # ---------- timeline / identity ----------
     @property
     def valuation_date(self) -> Date:
@@ -70,13 +75,29 @@ class Option(Instrument, ABC):
     @abstractmethod
     def _process(self) -> BlackScholesMertonProcess: ...
 
-    @abstractmethod
-    def npv_per_unit(self) -> float: ...
+    def _ensure_cached_option(self) -> QLVanillaOption:
+        eval_date = Settings.instance().evaluationDate
+        option = self._ql_option_cache
+        if (
+            option is None
+            or self._engine_cache is None
+            or self._process_cache is None
+            or self._cache_eval_date != eval_date
+        ):
+            process = self._process()
+            engine = self._engine(process)
+            option = QLVanillaOption(self._payoff, self._exercise)
+            option.setPricingEngine(engine)
+
+            object.__setattr__(self, "_process_cache", process)
+            object.__setattr__(self, "_engine_cache", engine)
+            object.__setattr__(self, "_ql_option_cache", option)
+            object.__setattr__(self, "_cache_eval_date", eval_date)
+
+        return option
 
     def _ql_option(self) -> QLVanillaOption:
-        opt = QLVanillaOption(self._payoff, self._exercise())
-        opt.setPricingEngine(self._engine)
-        return opt
+        return self._ensure_cached_option()
 
     def _position_multiplier(self) -> int:
         # uniform scaling across Instruments
@@ -86,47 +107,52 @@ class Option(Instrument, ABC):
     def npv(self) -> float:
         return self._position_multiplier() * self.npv_per_unit()
 
+    def npv_per_unit(self) -> float:
+        if self.is_expired:
+            return 0.0
+        return float(self._ensure_cached_option().NPV())
+
     # Per-contract greeks; subclasses can override/extend
     # The defaults try to use the QL analytic greeks when available.
     def delta(self) -> float:
         if self.is_expired:
             return 0.0
         try:
-            return float(self._ql_option().delta())
-        except Exception:
-            raise NotImplementedError("Delta not available for this engine/model.")
+            return float(self._ensure_cached_option().delta())
+        except Exception as err:
+            raise NotImplementedError("Delta not available for this engine/model.") from err
 
     def gamma(self) -> float:
         if self.is_expired:
             return 0.0
         try:
-            return float(self._ql_option().gamma())
-        except Exception:
-            raise NotImplementedError("Gamma not available for this engine/model.")
+            return float(self._ensure_cached_option().gamma())
+        except Exception as err:
+            raise NotImplementedError("Gamma not available for this engine/model.") from err
 
     def vega(self) -> float:
         if self.is_expired:
             return 0.0
         try:
-            return float(self._ql_option().vega())
-        except Exception:
-            raise NotImplementedError("Vega not available for this engine/model.")
+            return float(self._ensure_cached_option().vega())
+        except Exception as err:
+            raise NotImplementedError("Vega not available for this engine/model.") from err
 
     def rho(self) -> float:
         if self.is_expired:
             return 0.0
         try:
-            return float(self._ql_option().rho())
-        except Exception:
-            raise NotImplementedError("Rho not available for this engine/model.")
+            return float(self._ensure_cached_option().rho())
+        except Exception as err:
+            raise NotImplementedError("Rho not available for this engine/model.") from err
 
     def theta(self) -> float:
         if self.is_expired:
             return 0.0
         try:
-            return float(self._ql_option().theta())
-        except Exception:
-            raise NotImplementedError("Theta not available for this engine/model.")
+            return float(self._ensure_cached_option().theta())
+        except Exception as err:
+            raise NotImplementedError("Theta not available for this engine/model.") from err
 
     # Scaled greeks (match `npv()` scaling)
     def scaled_delta(self) -> float:

--- a/PricingEngine/Instruments/equity_option.py
+++ b/PricingEngine/Instruments/equity_option.py
@@ -116,9 +116,7 @@ class EquityOption(Option):
         return BlackScholesMertonProcess(self.spot, self.dividend_curve, self.risk_free_curve, self.vol)
 
     def _ql_option(self) -> QLVanillaOption:
-        ql = QLVanillaOption(self._payoff, self._exercise)
-        ql.setPricingEngine(self._engine(self._process()))
-        return ql
+        return self._ensure_cached_option()
 
     def _position_multiplier(self) -> float:
         # OPTION convention: per-position = per-unit * quantity * contract_size
@@ -127,7 +125,7 @@ class EquityOption(Option):
     def npv_per_unit(self) -> float:
         if self.is_expired:
             return 0.0
-        return float(self._ql_option().NPV())
+        return float(self._ensure_cached_option().NPV())
 
     # ------------- finite-difference bump helper -------------
     _EPS_S_REL = 1e-4
@@ -272,12 +270,12 @@ class EquityOption(Option):
         Per-unit theta, *per calendar day* (forward difference).
 
         Definition:
-          θ ≈ [V(t + Δt) − V(t)] / Δt_days, with Δt = 1 day by default.
+          theta ≈ [V(t + dt) - V(t)] / dt_days, with dt = 1 day by default.
 
         Notes:
-          - Sign: for most vanilla options, theta ≤ 0 (time decay).
-          - Units: result is per calendar day; use `total_theta()` to include quantity×contract_size.
-          - Engines that don’t expose theta will fall back to FD on the same process.
+          - Sign: for most vanilla options, theta <= 0 (time decay).
+          - Units: result is per calendar day; use `total_theta()` to include quantity*contract_size.
+          - Engines that don't expose theta will fall back to FD on the same process.
         """
         g = self._ql_greek("theta")
         if g is not None:

--- a/tests/PricingEngine/Instruments/test_option_caching.py
+++ b/tests/PricingEngine/Instruments/test_option_caching.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from QuantLib import (
+    Actual365Fixed,
+    AnalyticEuropeanEngine,
+    BlackConstantVol,
+    BlackScholesMertonProcess,
+    BlackVolTermStructureHandle,
+    Date,
+    EuropeanExercise,
+    FlatForward,
+    NullCalendar,
+    PlainVanillaPayoff,
+    QuoteHandle,
+    SavedSettings,
+    Settings,
+    SimpleQuote,
+    YieldTermStructureHandle,
+)
+from QuantLib import (
+    Option as QLOption,
+)
+
+from PricingEngine.Instruments.Common import Option
+
+
+@dataclass(frozen=True, kw_only=True)
+class CountingOption(Option):
+    quantity: int
+    strike: float
+    expiry: Date
+    spot: QuoteHandle
+    dividend_curve: YieldTermStructureHandle
+    risk_free_curve: YieldTermStructureHandle
+    vol: BlackVolTermStructureHandle
+
+    process_builds = 0
+    engine_builds = 0
+
+    def _expiry_date(self) -> Date:
+        return self.expiry
+
+    @property
+    def _payoff(self) -> PlainVanillaPayoff:
+        return PlainVanillaPayoff(QLOption.Call, float(self.strike))
+
+    @property
+    def _exercise(self) -> EuropeanExercise:
+        return EuropeanExercise(self.expiry)
+
+    def _engine(self, process: BlackScholesMertonProcess) -> AnalyticEuropeanEngine:
+        type(self).engine_builds += 1
+        return AnalyticEuropeanEngine(process)
+
+    def _process(self) -> BlackScholesMertonProcess:
+        type(self).process_builds += 1
+        return BlackScholesMertonProcess(
+            self.spot,
+            self.dividend_curve,
+            self.risk_free_curve,
+            self.vol,
+        )
+
+
+def _flat_term_structure(rate: float) -> YieldTermStructureHandle:
+    valuation_date = Settings.instance().evaluationDate
+    return YieldTermStructureHandle(FlatForward(valuation_date, rate, Actual365Fixed()))
+
+
+def _flat_vol(vol: float) -> BlackVolTermStructureHandle:
+    valuation_date = Settings.instance().evaluationDate
+    return BlackVolTermStructureHandle(BlackConstantVol(valuation_date, NullCalendar(), vol, Actual365Fixed()))
+
+
+def _make_option() -> CountingOption:
+    CountingOption.process_builds = 0
+    CountingOption.engine_builds = 0
+
+    settings = Settings.instance()
+    valuation_date = settings.evaluationDate
+    expiry = valuation_date + 30
+
+    spot = QuoteHandle(SimpleQuote(100.0))
+    dividend = _flat_term_structure(0.0)
+    risk_free = _flat_term_structure(0.01)
+    vol = _flat_vol(0.2)
+
+    return CountingOption(
+        quantity=1,
+        strike=100.0,
+        expiry=expiry,
+        spot=spot,
+        dividend_curve=dividend,
+        risk_free_curve=risk_free,
+        vol=vol,
+    )
+
+
+def test_option_reuses_cached_quantlib_objects():
+    with SavedSettings():
+        Settings.instance().evaluationDate = Date(15, 5, 2024)
+        opt = _make_option()
+
+        first = opt.npv_per_unit()
+        second = opt.npv_per_unit()
+
+        assert second == pytest.approx(first)
+        assert CountingOption.process_builds == 1
+        assert CountingOption.engine_builds == 1
+
+        first_delta = opt.delta()
+        second_delta = opt.delta()
+
+        assert second_delta == pytest.approx(first_delta)
+        assert CountingOption.process_builds == 1
+        assert CountingOption.engine_builds == 1
+
+        assert opt._ql_option() is opt._ql_option()


### PR DESCRIPTION
## Summary
- add QuantLib object caches and a helper on the base `Option` to reuse payoffs, processes, engines, and vanilla options across valuations
- update equity options to rely on the shared cache-aware path for pricing and greeks
- add a regression test that ensures repeated pricing/greek calls reuse cached builders

## Testing
- poetry run ruff check PricingEngine/Instruments/Common/_option.py PricingEngine/Instruments/equity_option.py tests/PricingEngine/Instruments/test_option_caching.py
- poetry run pytest tests/PricingEngine/Instruments/test_option_caching.py

------
https://chatgpt.com/codex/tasks/task_e_68e418b3fe84832f8b856b89de332a33