### PR TITLE
Simplify equity option QuantLib construction

### DIFF
--- a/PricingEngine/Instruments/__init__.py
+++ b/PricingEngine/Instruments/__init__.py
@@ -4,6 +4,7 @@ from .cross_currency_swap import CrossCurrencySwap
 from .equity_option import (
     AmericanVanillaOption,
     BermudanVanillaOption,
+    EquityOption,
     EuropeanDigitalOption,
     EuropeanVanillaOption,
 )
@@ -20,6 +21,7 @@ from .swaption import Swaption
 __all__ = [
     "AmericanVanillaOption",
     "BermudanVanillaOption",
+    "EquityOption",
     "EuropeanDigitalOption",
     "EuropeanVanillaOption",
     "CrossCurrencySwap",

--- a/PricingEngine/Instruments/equity_option.py
+++ b/PricingEngine/Instruments/equity_option.py
@@ -34,8 +34,6 @@ from QuantLib import (  # Core dates/settings
 )
 from QuantLib import (
     Option as QLOption,  # day count / comp
-)
-from QuantLib import (
     VanillaOption as QLVanillaOption,
 )
 
@@ -115,17 +113,9 @@ class EquityOption(Option):
     def _process(self) -> BlackScholesMertonProcess:
         return BlackScholesMertonProcess(self.spot, self.dividend_curve, self.risk_free_curve, self.vol)
 
-    def _ql_option(self) -> QLVanillaOption:
-        return self._ensure_cached_option()
-
     def _position_multiplier(self) -> float:
         # OPTION convention: per-position = per-unit * quantity * contract_size
         return float(self.quantity) * float(self.contract_size)
-
-    def npv_per_unit(self) -> float:
-        if self.is_expired:
-            return 0.0
-        return float(self._ensure_cached_option().NPV())
 
     # ------------- finite-difference bump helper -------------
     _EPS_S_REL = 1e-4
@@ -188,18 +178,23 @@ class EquityOption(Option):
         if bump_days:
             with SavedSettings():
                 Settings.instance().evaluationDate = self.valuation_date + Period(f"{int(bump_days)}D")
-                ql = QLVanillaOption(self._payoff, self._exercise)
-                ql.setPricingEngine(self._engine(proc))
-                return float(ql.NPV())
-        else:
-            ql = QLVanillaOption(self._payoff, self._exercise)
-            ql.setPricingEngine(self._engine(proc))
-            return float(ql.NPV())
+                option = QLVanillaOption(self._payoff, self._exercise)
+                option.setPricingEngine(self._engine(proc))
+                return float(option.NPV())
+
+        option = QLVanillaOption(self._payoff, self._exercise)
+        option.setPricingEngine(self._engine(proc))
+        return float(option.NPV())
 
     # ------------- engine-or-FD greek wrapper (per unit) -------------
     def _ql_greek(self, name: str) -> float | None:
+        if self.is_expired:
+            return 0.0
+
+        option = self._ensure_cached_option()
+
         try:
-            val = float(getattr(self._ql_option(), name)())
+            val = float(getattr(option, name)())
             self._trace_greek(greek=name, source="engine", engine=self.engine_params.kind, value=val)
             return val
         except Exception:

--- a/tests/PricingEngine/Instruments/test_equity_option.py
+++ b/tests/PricingEngine/Instruments/test_equity_option.py
@@ -2,6 +2,7 @@
 from copy import copy
 import dataclasses
 import math
+from unittest.mock import patch
 
 import pytest
 from QuantLib import (
@@ -32,6 +33,7 @@ from QuantLib import (
 from PricingEngine.Instruments import (
     AmericanVanillaOption,
     BermudanVanillaOption,
+    EquityOption,
     EuropeanDigitalOption,
     EuropeanVanillaOption,
 )
@@ -1073,6 +1075,98 @@ class TestE_EngineMatrixExhaustive:
                     getattr(ql, greek)()
                 o_val = getattr(opt, greek)()
                 assert math.isfinite(o_val), f"{type(opt).__name__}.{greek} must be finite via FD fallback"
+
+
+# ---------------------------------------------------------------------------
+# Regression: caching & bumping semantics
+# ---------------------------------------------------------------------------
+
+
+class TestZ_CachingAndBumps:
+    def test_repeated_price_and_greeks_reuse_cached_option(self, euro_call):
+        opt = euro_call
+
+        with (
+            patch.object(
+                EquityOption,
+                "_process",
+                wraps=EquityOption._process,
+                autospec=True,
+            ) as process_spy,
+            patch.object(
+                EuropeanVanillaOption,
+                "_engine",
+                wraps=EuropeanVanillaOption._engine,
+                autospec=True,
+            ) as engine_spy,
+        ):
+            price1 = opt.npv_per_unit()
+            price2 = opt.npv_per_unit()
+
+            assert price2 == pytest.approx(price1)
+
+            for name in ("delta", "gamma", "vega", "rho", "theta"):
+                first = getattr(opt, name)()
+                second = getattr(opt, name)()
+                assert second == pytest.approx(first)
+
+            cached_option = opt._ql_option_cache
+            cached_engine = opt._engine_cache
+            cached_process = opt._process_cache
+            assert cached_option is not None
+            assert cached_engine is not None
+            assert cached_process is not None
+
+        assert process_spy.call_count == 1
+        assert engine_spy.call_count == 1
+
+        assert cached_option is opt._ql_option_cache
+        assert cached_engine is opt._engine_cache
+        assert cached_process is opt._process_cache
+
+    def test_theta_fd_bump_uses_fresh_engine(self, euro_call):
+        opt = euro_call
+
+        with patch.object(
+            EuropeanVanillaOption,
+            "_engine",
+            wraps=EuropeanVanillaOption._engine,
+            autospec=True,
+        ) as engine_spy:
+            baseline_price = opt.npv_per_unit()
+            assert baseline_price == pytest.approx(opt.npv_per_unit())
+
+            cached_option = opt._ql_option_cache
+            cached_engine = opt._engine_cache
+            cached_process = opt._process_cache
+
+            with patch.object(QLVanillaOption, "theta", side_effect=RuntimeError("no theta")):
+                theta1 = opt.theta()
+                theta2 = opt.theta()
+
+            assert theta2 == pytest.approx(theta1)
+
+        assert engine_spy.call_count == 3  # 1 cached + 2 bump builds
+        assert opt._ql_option_cache is cached_option
+        assert opt._engine_cache is cached_engine
+        assert opt._process_cache is cached_process
+
+    def test_expired_trade_short_circuits_without_building(self, euro_call):
+        opt = euro_call
+
+        with SavedSettings():
+            Settings.instance().evaluationDate = opt.maturity + Period("5D")
+
+            assert opt.npv_per_unit() == 0.0
+            assert opt.delta() == 0.0
+            assert opt.gamma() == 0.0
+            assert opt.vega() == 0.0
+            assert opt.rho() == 0.0
+            assert opt.theta() == 0.0
+
+        assert opt._ql_option_cache is None
+        assert opt._engine_cache is None
+        assert opt._process_cache is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- inline the QuantLib option creation inside the caching path to drop the extra helper method
- rebuild finite-difference bump pricing inline and export `EquityOption` from the package for shared imports
- update the regression tests to import `EquityOption` via the Instruments package

## Testing
- poetry run pytest tests/PricingEngine/Instruments/test_equity_option.py -q
- poetry run ruff check

------
https://chatgpt.com/codex/tasks/task_e_68e41b3d1250832f999690484b29dd03